### PR TITLE
Don't retry close() on EINTR or EIO.

### DIFF
--- a/src/ngx_base_fetch.cc
+++ b/src/ngx_base_fetch.cc
@@ -151,10 +151,8 @@ bool NgxBaseFetch::HandleFlush(MessageHandler* handler) {
 void NgxBaseFetch::HandleDone(bool success) {
   done_called_ = true;
   RequestCollection('F');  // finished; can close the pipe.
-  int rc; 
-  do {
-    rc = close(pipe_fd_);
-  } while (errno == EINTR || errno == EIO);
+  close(pipe_fd_);
+  pipe_fd_ = -1;
 }
 
 }  // namespace net_instaweb


### PR DESCRIPTION
Quoting from the POSIX-1.2001 spec:

  If close() is interrupted by a signal that is to be caught, it shall return
  -1 with errno set to [EINTR] and the state of fildes is unspecified. If an
  I/O error occurred while reading from or writing to the file system during
  close(), it may return -1 with errno set to [EIO]; if this error is returned,
  the state of fildes is unspecified.

In other words, it's not safe to retry.

The actual behavior that the major Unices implement is that the file descriptor
is closed regardless of the returned error code. In that case it's actually
harmful to retry the close because we might be closing a file descriptor that's
been freshly allocated by another thread.

/cc @jeffkaufman
