### PR TITLE
Support Custom Options

### DIFF
--- a/src/ngx_base_fetch.cc
+++ b/src/ngx_base_fetch.cc
@@ -25,19 +25,40 @@ namespace net_instaweb {
 
 NgxBaseFetch::NgxBaseFetch(ngx_http_request_t* r, int pipe_fd)
     : request_(r), done_called_(false), pipe_fd_(pipe_fd) {
+  PopulateRequestHeaders();
 }
 
 NgxBaseFetch::~NgxBaseFetch() { }
 
-void NgxBaseFetch::PopulateHeaders() {
+void NgxBaseFetch::PopulateRequestHeaders() {
+  CopyHeadersFromTable<RequestHeaders>(&request_->headers_in.headers,
+                                       request_headers());
+}
+
+void NgxBaseFetch::PopulateResponseHeaders() {
+  CopyHeadersFromTable<ResponseHeaders>(&request_->headers_out.headers,
+                                        response_headers());
+
+  // For some reason content_type is not included in
+  // request_->headers_out.headers, which means I don't fully understand how
+  // headers_out works, but manually copying over content type works.
+  response_headers()->Add(
+      HttpAttributes::kContentType,
+      ngx_http_pagespeed_str_to_string_piece(
+          &request_->headers_out.content_type));
+}
+
+template<class HeadersT>
+void NgxBaseFetch::CopyHeadersFromTable(ngx_list_t* headers_from,
+                                        HeadersT* headers_to) {
   // http_version is the version number of protocol; 1.1 = 1001. See
   // NGX_HTTP_VERSION_* in ngx_http_request.h 
-  response_headers()->set_major_version(request_->http_version / 1000);
-  response_headers()->set_minor_version(request_->http_version % 1000);
+  headers_to->set_major_version(request_->http_version / 1000);
+  headers_to->set_minor_version(request_->http_version % 1000);
 
   // Standard nginx idiom for iterating over a list.  See ngx_list.h
   ngx_uint_t i;
-  ngx_list_part_t* part = &request_->headers_out.headers.part;
+  ngx_list_part_t* part = &headers_from->part;
   ngx_table_elt_t* header = static_cast<ngx_table_elt_t*>(part->elts);
 
   for (i = 0 ; /* void */; i++) {
@@ -55,15 +76,8 @@ void NgxBaseFetch::PopulateHeaders() {
     StringPiece value = ngx_http_pagespeed_str_to_string_piece(
         &header[i].value);
 
-    response_headers()->Add(key, value);
+    headers_to->Add(key, value);
   }
-
-  // For some reason content_type is not included in
-  // request_->headers_out.headers, which means I don't fully understand how
-  // headers_out works, but manually copying over content type works.
-  StringPiece content_type = ngx_http_pagespeed_str_to_string_piece(
-      &request_->headers_out.content_type);
-  response_headers()->Add(HttpAttributes::kContentType, content_type);
 }
 
 bool NgxBaseFetch::HandleWrite(const StringPiece& sp,

--- a/src/ngx_base_fetch.h
+++ b/src/ngx_base_fetch.h
@@ -37,6 +37,7 @@ extern "C" {
 }
 
 #include "net/instaweb/http/public/async_fetch.h"
+#include "net/instaweb/http/public/headers.h"
 #include "net/instaweb/util/public/string.h"
 
 namespace net_instaweb {
@@ -46,8 +47,11 @@ class NgxBaseFetch : public AsyncFetch {
   NgxBaseFetch(ngx_http_request_t* r, int pipe_fd);
   virtual ~NgxBaseFetch();
 
+  // Copies the request headers out of request_->headers_in->headers.
+  void PopulateRequestHeaders();
+
   // Copies the response headers out of request_->headers_out->headers.
-  void PopulateHeaders();
+  void PopulateResponseHeaders();
 
   // Puts a chain link in link_ptr if we have any output data buffered.  Returns
   // NGX_OK on success, NGX_ERROR on errors.  If there's no data to send, sends
@@ -65,6 +69,11 @@ class NgxBaseFetch : public AsyncFetch {
   virtual bool HandleFlush(MessageHandler* handler);
   virtual void HandleHeadersComplete() {}
   virtual void HandleDone(bool success);
+
+  
+  // Helper method for PopulateRequestHeaders and PopulateResponseHeaders.
+  template<class HeadersT>
+  void CopyHeadersFromTable(ngx_list_t* headers_from, HeadersT* headers_to);
 
   // Indicate to nginx that we would like it to call
   // CollectAccumulatedWrites().

--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -618,7 +618,8 @@ ngx_http_pagespeed_body_filter(ngx_http_request_t* r, ngx_chain_t* in) {
     // Call this here and not in the header filter because we want to see the
     // headers after any other filters are finished modifying them.  At this
     // point they are final.
-    ctx->base_fetch->PopulateHeaders();  // TODO(jefftk): is this thread safe?
+    // TODO(jefftk): is this thread safe?
+    ctx->base_fetch->PopulateResponseHeaders();
   }
 
   if (in != NULL) {


### PR DESCRIPTION
Pass headers and query parameters that change options through to Pagespeed.  While the add_instrumentation filter is currently off by default, either of these commands below would fetch the example file with the filter on:

```
 curl 'http://localhost:8050/mod_pagespeed_example/add_instrumentation.html?ModPagespeedFilters=add_instrumentation'
 curl --header 'ModPagespeedFilters:add_instrumentation' 'http://localhost:8050/mod_pagespeed_example/add_instrumentation.html'
```

Compared to just `curl 'http://localhost:8050/mod_pagespeed_example/add_instrumentation.html` the difference is that there's a chunk of complicated javascript at the end added by the filter.

You'll need to sync mod_pagespeed to trunk to compile this; it uses GetQueryOptions which recently had it's signature changed.
