### PR TITLE
Respect ModPagespeed=off

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -779,6 +779,10 @@ ngx_http_pagespeed_header_filter(ngx_http_request_t* r) {
     return ngx_http_next_header_filter(r);
   }
 
+  if (r->err_status != 0) {
+    return ngx_http_next_header_filter(r);
+  }
+
   // We don't know what this request is, but we only want to send html through
   // to pagespeed.  Check the content type header and find out.
   const net_instaweb::ContentType* content_type = 
@@ -787,11 +791,6 @@ ngx_http_pagespeed_header_filter(ngx_http_request_t* r) {
               &r->headers_out.content_type));
   if (content_type == NULL || !content_type->IsHtmlLike()) {
     // Unknown or otherwise non-html content type: skip it.
-    CHECK(ctx == NULL);
-    return ngx_http_next_header_filter(r);
-  }
-
-  if (r->err_status != 0) {
     return ngx_http_next_header_filter(r);
   }
 


### PR DESCRIPTION
One of the things you can do with headers or query params is turn off mod pagespeed:

```
curl -D- 'http://localhost:8050/mod_pagespeed_example/combine_css.html'
curl -D- 'http://localhost:8050/mod_pagespeed_example/combine_css.html?ModPagespeed=off'
```

We weren't respecting this fully before, still removing the etag, dropping the content length, etc.
