### PR TITLE
Don't run furious when we got options from the query string or from headers.

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -618,9 +618,12 @@ ngx_http_pagespeed_create_request_context(ngx_http_request_t* r,
   // If the global options say we're running furious (the experiment framework)
   // then clone them into custom_options so we can manipulate custom options
   // without affecting the global options.
+  //
+  // If custom_options were set above in GetQueryOptions() don't run furious.
+  // We don't want experiments to be contaminated with unexpected settings.
   net_instaweb::RewriteOptions* global_options =
       ctx->cfg->server_context->global_options();
-  if (global_options->running_furious()) {
+  if (custom_options == NULL && global_options->running_furious()) {
     custom_options = global_options->Clone();
     custom_options->set_need_to_store_experiment_data(
         ctx->cfg->server_context->furious_matcher()->ClassifyIntoExperiment(


### PR DESCRIPTION
If custom_options were set by GetQueryOptions(), don't run the experiment framework.  We don't want experiments to be contaminated with unexpected settings.
