### PR TITLE
ngx_base_fetch: implement locking

### DIFF
--- a/config
+++ b/config
@@ -57,7 +57,7 @@ pagespeed_include="$mod_pagespeed_dir
                    $mod_pagespeed_dir/third_party/aprutil/gen/arch/$os_name/$arch_name/include/"
 ngx_feature_path="$pagespeed_include"
 pagespeed_automatic_dir="$mod_pagespeed_dir/net/instaweb/automatic"
-pagespeed_libs="-lstdc++ $pagespeed_automatic_dir/pagespeed_automatic.a -lrt"
+pagespeed_libs="-lstdc++ $pagespeed_automatic_dir/pagespeed_automatic.a -lrt -pthread"
 ngx_feature_libs="$pagespeed_libs"
 ngx_feature_test="
     GoogleString output_buffer;

--- a/src/ngx_base_fetch.cc
+++ b/src/ngx_base_fetch.cc
@@ -27,10 +27,21 @@ namespace net_instaweb {
 NgxBaseFetch::NgxBaseFetch(ngx_http_request_t* r, int pipe_fd)
     : request_(r), done_called_(false), last_buf_sent_(false),
       pipe_fd_(pipe_fd) {
+  if (pthread_mutex_init(&mutex_, NULL)) CHECK(0);
   PopulateRequestHeaders();
 }
 
-NgxBaseFetch::~NgxBaseFetch() { }
+NgxBaseFetch::~NgxBaseFetch() {
+  pthread_mutex_destroy(&mutex_);
+}
+
+void NgxBaseFetch::Lock() {
+  pthread_mutex_lock(&mutex_);
+}
+
+void NgxBaseFetch::Unlock() {
+  pthread_mutex_unlock(&mutex_);
+}
 
 void NgxBaseFetch::PopulateRequestHeaders() {
   CopyHeadersFromTable<RequestHeaders>(&request_->headers_in.headers,

--- a/src/ngx_base_fetch.h
+++ b/src/ngx_base_fetch.h
@@ -33,6 +33,7 @@
 #define NGX_BASE_FETCH_H_
 
 extern "C" {
+#include <pthread.h>
 #include <ngx_http.h>
 }
 
@@ -92,21 +93,15 @@ class NgxBaseFetch : public AsyncFetch {
   // buffer_.
   ngx_int_t CopyBufferToNginx(ngx_chain_t** link_ptr);
 
-  // Acquire this lock before manipulating buffer_.
-  // TODO(jefftk): Actually implement this.  Possibly with ngx_shmtx_lock and
-  // ngx_shmtx_unlock.
-  void Lock() {
-    fprintf(stderr, "Would lock buffer_\n");
-  }
-  void Unlock() {
-    fprintf(stderr, "Would unlock buffer_\n");
-  }
+  void Lock();
+  void Unlock();
 
   ngx_http_request_t* request_;
   GoogleString buffer_;
   bool done_called_;
   bool last_buf_sent_;
   int pipe_fd_;
+  pthread_mutex_t mutex_;
 
   DISALLOW_COPY_AND_ASSIGN(NgxBaseFetch);
 };


### PR DESCRIPTION
Implement the Lock() and Unlock() methods. It uses a spinlock because:

a) ngx_mutex_t is only available when NGX_THREADS is defined (which is never).
b) ngx_shmtx_t is a spinlock in disguise that falls back to a semaphore after a few spins, but:
c) ngx_pagespeed doesn't do hugely expensive things in its critical sections. It seems a shame risk getting rescheduled just because there's a few nanoseconds of contention.

That said, I don't mind rewriting it as ngx_shm code if people feel strongly about it. :-)
