### PR TITLE
headers: content type

### DIFF
--- a/src/ngx_base_fetch.cc
+++ b/src/ngx_base_fetch.cc
@@ -235,6 +235,10 @@ ngx_int_t NgxBaseFetch::CollectHeaders(ngx_http_headers_out_t* headers_out) {
       // Unlike all the other headers, content_type is just a string.
       headers_out->content_type.data = value_s;
       headers_out->content_type.len = value.len;
+      headers_out->content_type_len = value.len;
+      // In ngx_http_test_content_type() nginx will allocate and calculate
+      // content_type_lowcase if we leave it as null.
+      headers_out->content_type_lowcase = NULL;
       continue;
     }
 


### PR DESCRIPTION
When setting content type you also need to set content_type_len and null out
content_type_lowcase or else downstream filters might look in the wrong place
for it.

See:
  http://stackoverflow.com/questions/8427528/nginx-gzip
  http://lxr.evanmiller.org/http/source/http/ngx_http_core_module.c#L1659
