### PR TITLE
ngx_pagespeed.cc: fix double request finalization (issue 79)

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -1025,8 +1025,9 @@ ngx_http_pagespeed_header_filter(ngx_http_request_t* r) {
       // properly after ourselves somewhere?
       return NGX_ERROR;
     case CreateRequestContext::kNotUnderstood:
-      CHECK(!"This should only happen when ctx->is_resource_fetch is true"
-            ", in which case we can not get here");
+      // This should only happen when ctx->is_resource_fetch is true,
+      // in which case we can not get here.
+      CHECK(false);
       return NGX_ERROR;
     case CreateRequestContext::kPagespeedDisabled:
     case CreateRequestContext::kStaticContent:


### PR DESCRIPTION
When returning NGX_ERROR in the header filter, apperently nginx
already finalizes the http request for us. This fixes 
https://github.com/pagespeed/ngx_pagespeed/issues/79

It also puts a check in place for a switch label that should be impossible to reach.
