### PR TITLE
housekeeping: use prefix `ps_` instead of `ngx_http_pagespeed_`

### DIFF
--- a/src/ngx_base_fetch.cc
+++ b/src/ngx_base_fetch.cc
@@ -58,10 +58,9 @@ void NgxBaseFetch::PopulateResponseHeaders() {
   // request_->headers_out.headers.
   response_headers()->Add(
       HttpAttributes::kContentType,
-      ngx_http_pagespeed_str_to_string_piece(
-          request_->headers_out.content_type));
+      ngx_psol::str_to_string_piece(request_->headers_out.content_type));
 
-  //TODO(oschaaf): ComputeCaching should be called in setupforhtml()?
+  // TODO(oschaaf): ComputeCaching should be called in setupforhtml()?
   response_headers()->ComputeCaching();
 }
 
@@ -89,8 +88,8 @@ void NgxBaseFetch::CopyHeadersFromTable(ngx_list_t* headers_from,
       i = 0;
     }
 
-    StringPiece key = ngx_http_pagespeed_str_to_string_piece(header[i].key);
-    StringPiece value = ngx_http_pagespeed_str_to_string_piece(header[i].value);
+    StringPiece key = ngx_psol::str_to_string_piece(header[i].key);
+    StringPiece value = ngx_psol::str_to_string_piece(header[i].value);
 
     headers_to->Add(key, value);
   }
@@ -108,7 +107,7 @@ ngx_int_t NgxBaseFetch::CopyBufferToNginx(ngx_chain_t** link_ptr) {
   // TODO(jefftk): if done_called_ && last_buf_sent_, should we just short
   // circuit (return NGX_OK) here?
 
-  int rc = ngx_http_pagespeed_string_piece_to_buffer_chain(
+  int rc = ngx_psol::string_piece_to_buffer_chain(
       request_->pool, buffer_, link_ptr, done_called_ /* send_last_buf */);
   if (rc != NGX_OK) {
     return rc;

--- a/src/ngx_pagespeed.h
+++ b/src/ngx_pagespeed.h
@@ -25,16 +25,17 @@ extern "C" {
 
 #include "net/instaweb/util/public/string_util.h"
 
+namespace ngx_psol {
+
 // Allocate chain links and buffers from the supplied pool, and copy over the
 // data from the string piece.  If the string piece is empty, return
 // NGX_DECLINED immediately unless send_last_buf.
 ngx_int_t
-ngx_http_pagespeed_string_piece_to_buffer_chain(
-    ngx_pool_t* pool, StringPiece sp, ngx_chain_t** link_ptr,
-    bool send_last_buf);
+string_piece_to_buffer_chain(ngx_pool_t* pool, StringPiece sp,
+                             ngx_chain_t** link_ptr, bool send_last_buf);
 
 StringPiece
-ngx_http_pagespeed_str_to_string_piece(ngx_str_t s);
+str_to_string_piece(ngx_str_t s);
 
 // s1: ngx_str_t, s2: string literal
 // true if they're equal, false otherwise
@@ -45,6 +46,8 @@ ngx_http_pagespeed_str_to_string_piece(ngx_str_t s);
 // Allocate memory out of the pool for the string piece, and copy the contents
 // over.  Returns NULL if we can't get memory.
 char*
-ngx_http_string_piece_to_pool_string(ngx_pool_t* pool, StringPiece sp);
+string_piece_to_pool_string(ngx_pool_t* pool, StringPiece sp);
+
+}  // namespace ngx_psol
 
 #endif  // NGX_PAGESPEED_H_

--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -279,7 +279,7 @@ NgxRewriteOptions::ParseAndSetOptions(
         StrAppend(&full_directive, i == 0 ? "" : " ", args[i]);
       }
       StrAppend(&full_directive, "\": ", msg);
-      char* s = ngx_http_string_piece_to_pool_string(pool, full_directive);
+      char* s = ngx_psol::string_piece_to_pool_string(pool, full_directive);
       if (s == NULL) {
         return "failed to allocate memory";
       }


### PR DESCRIPTION
Within the anonymous namespace in ngx_pagespeed.css we don't really need to be
using the long `ngx_http_pagespeed_` prefix.  Switching to just `ps_` should be
safe.  For symbols that need to be visible outside this file, though, we need to
keep the long prefix.

Fixes #85.
