### PR TITLE
fetch: support proxy

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -453,7 +453,8 @@ ps_merge_srv_conf(ngx_conf_t* cf, void* parent, void* child) {
     // we're done with it.  That never happens, though, because this is the
     // top-level config and so sticks around as long as we're running.
 
-    cfg_m->driver_factory = new net_instaweb::NgxRewriteDriverFactory();
+    cfg_m->driver_factory = new net_instaweb::NgxRewriteDriverFactory(
+        parent_cfg_s->options);
   }
 
   cfg_s->server_context = new net_instaweb::NgxServerContext(

--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -72,9 +72,10 @@ class Writer;
 
 const char NgxRewriteDriverFactory::kMemcached[] = "memcached";
 
-NgxRewriteDriverFactory::NgxRewriteDriverFactory() :
+NgxRewriteDriverFactory::NgxRewriteDriverFactory(NgxRewriteOptions* main_conf) :
   shared_mem_runtime_(new NullSharedMem()),
-  cache_hasher_(20) {
+  cache_hasher_(20),
+  main_conf_(main_conf) {
   RewriteDriverFactory::InitStats(&simple_stats_);
   SerfUrlAsyncFetcher::InitStats(&simple_stats_);
   AprMemCache::InitStats(&simple_stats_);
@@ -120,9 +121,14 @@ UrlFetcher* NgxRewriteDriverFactory::DefaultUrlFetcher() {
 }
 
 UrlAsyncFetcher* NgxRewriteDriverFactory::DefaultAsyncUrlFetcher() {
+  const char* fetcher_proxy = "";
+  if (main_conf_ != NULL) {
+    fetcher_proxy = main_conf_->fetcher_proxy().c_str();
+  }
+
   net_instaweb::UrlAsyncFetcher* fetcher =
       new net_instaweb::SerfUrlAsyncFetcher(
-          "",
+          fetcher_proxy,
           pool_,
           thread_system(),
           statistics(),

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -47,7 +47,9 @@ class NgxRewriteDriverFactory : public RewriteDriverFactory {
   static const char kStaticJavaScriptPrefix[];
   static const char kMemcached[];
 
-  NgxRewriteDriverFactory();
+  // main_conf will have only options set in the main block.  It may be NULL,
+  // and we do not take ownership.
+  NgxRewriteDriverFactory(NgxRewriteOptions* main_conf);
   virtual ~NgxRewriteDriverFactory();
   virtual Hasher* NewHasher();
   virtual UrlFetcher* DefaultUrlFetcher();
@@ -102,6 +104,7 @@ private:
   typedef std::map<GoogleString, NgxCache*> PathCacheMap;
   PathCacheMap path_cache_map_;
   MD5Hasher cache_hasher_;
+  NgxRewriteOptions* main_conf_;
 
   // memcache connections are expensive.  Just allocate one per
   // distinct server-list.  At the moment there is no consistency

--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -71,6 +71,8 @@ void NgxRewriteOptions::AddProperties() {
                  RewriteOptions::kMemcachedThreads);
   add_ngx_option(false, &NgxRewriteOptions::use_shared_mem_locking_, "ausml",
                  RewriteOptions::kUseSharedMemLocking);
+  add_ngx_option("", &NgxRewriteOptions::fetcher_proxy_, "afp",
+                 RewriteOptions::kFetcherProxy);
 
   MergeSubclassProperties(ngx_properties_);
   NgxRewriteOptions config;

--- a/src/ngx_rewrite_options.h
+++ b/src/ngx_rewrite_options.h
@@ -125,6 +125,12 @@ class NgxRewriteOptions : public RewriteOptions {
   void set_memcached_threads(int x) {
     set_option(x, &memcached_threads_);
   }
+  const GoogleString& fetcher_proxy() const {
+    return fetcher_proxy_.value();
+  }
+  void set_fetcher_proxy(GoogleString x) {
+    set_option(x, &fetcher_proxy_);
+  }
  private:
   // Used by class_name() and DynamicCast() to provide error checking.
   static const char kClassName[];
@@ -179,6 +185,8 @@ class NgxRewriteOptions : public RewriteOptions {
   // ignoring case.
   bool IsDirective(StringPiece config_directive, StringPiece compare_directive);
 
+  // TODO(jefftk): support fetch proxy in server and location blocks.
+  Option<GoogleString> fetcher_proxy_;
   Option<GoogleString> file_cache_path_;
   Option<int64> file_cache_clean_inode_limit_;
   Option<int64> file_cache_clean_interval_ms_;


### PR DESCRIPTION
Example:

```
pagespeed FetchProxy        127.0.0.1:8081;
```

With a proxy set the fetcher will send all outside requests through the proxy.
Like ModPagespeedFetchProxy, this is intended to be used for load tests.

For now, this must be set in the 'http' block.

Fixes #98, and is needed for #41.
