### PR TITLE
request context: deal with changes in pagespeed's api

### DIFF
--- a/src/ngx_base_fetch.cc
+++ b/src/ngx_base_fetch.cc
@@ -24,9 +24,10 @@
 
 namespace net_instaweb {
 
-NgxBaseFetch::NgxBaseFetch(ngx_http_request_t* r, int pipe_fd)
-    : request_(r), done_called_(false), last_buf_sent_(false),
-      pipe_fd_(pipe_fd) {
+NgxBaseFetch::NgxBaseFetch(ngx_http_request_t* r, int pipe_fd,
+                           const RequestContextPtr& request_ctx)
+  : AsyncFetch(request_ctx), request_(r), done_called_(false),
+    last_buf_sent_(false), pipe_fd_(pipe_fd) {
   if (pthread_mutex_init(&mutex_, NULL)) CHECK(0);
   PopulateRequestHeaders();
 }

--- a/src/ngx_base_fetch.h
+++ b/src/ngx_base_fetch.h
@@ -45,7 +45,8 @@ namespace net_instaweb {
 
 class NgxBaseFetch : public AsyncFetch {
  public:
-  NgxBaseFetch(ngx_http_request_t* r, int pipe_fd);
+  NgxBaseFetch(ngx_http_request_t* r, int pipe_fd,
+               const RequestContextPtr& request_ctx);
   virtual ~NgxBaseFetch();
 
   // Copies the request headers out of request_->headers_in->headers.

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -48,6 +48,7 @@ PAGESPEED_EXPECTED_FAILURES="
   ~compression is enabled for rewritten JS.~
   ~convert_meta_tags~
   ~regression test with same filtered input twice in combination~
+  ~insert_dns_prefetch~
 "
 
 source $SYSTEM_TEST_FILE


### PR DESCRIPTION
The pagespeed api for handling logs has changed, we need to change with it in
order to build against the latest pagespeed optimization libraries.

Separately, a new test was added to the generic system test that depends on the
property cache (insert_dns_prefetch).  We've not ported the property cache yet,
so this test will fail, and I've added it to the list of failing tests.
