### PR TITLE
cache: fixes

### DIFF
--- a/src/ngx_cache.cc
+++ b/src/ngx_cache.cc
@@ -51,7 +51,9 @@ NgxCache::NgxCache(const StringPiece& path,
   } else {
     FallBackToFileBasedLocking();
   }
-
+  
+  // TODO(jefftk): see the ngx_rewrite_options.h note on OriginRewriteOptions;
+  // this would move to OriginRewriteOptions.
   FileCache::CachePolicy* policy = new FileCache::CachePolicy(
       factory->timer(),
       factory->hasher(),


### PR DESCRIPTION
- restores slow worker initialization/termination
- amend an error I apparently made while rebasing to head:
  - do not null the lru cache when using memcached (accidentally
    left in)
  - remove debug fprintf's
  - remove comment about virtual hosts
  - restore a TODO
  - abort when memcached is configure and we fail to connect
    to the memcached interface
