### PR TITLE
headers: strip accept-bytes and vary-accept-encoding

### DIFF
--- a/src/ngx_pagespeed.h
+++ b/src/ngx_pagespeed.h
@@ -43,6 +43,15 @@ str_to_string_piece(ngx_str_t s);
     ((s1).len == (sizeof(s2)-1) &&      \
      ngx_strncmp((s1).data, (s2), (sizeof(s2)-1)) == 0)
 
+// s1: ngx_str_t, s2: string literal
+// true if they're equal ignoring case, false otherwise
+#define STR_CASE_EQ_LITERAL(s1, s2)     \
+    ((s1).len == (sizeof(s2)-1) &&      \
+     ngx_strncasecmp((s1).data, (       \
+       reinterpret_cast<u_char*>(       \
+         const_cast<char*>(s2))),       \
+       (sizeof(s2)-1)) == 0)
+
 // Allocate memory out of the pool for the string piece, and copy the contents
 // over.  Returns NULL if we can't get memory.
 char*


### PR DESCRIPTION
If we're proxying the origin server might advertise `Accept-Ranges: bytes` but
we don't support range requests.  So we need to remove the header.  We also need
to not add `Vary: Accept-Encoding` twice, and because the gzip encoding will add
it later we need to remove it here.
