### PR TITLE
config: interpret amd64, i686, and i386

### DIFF
--- a/config
+++ b/config
@@ -52,9 +52,10 @@ else
   exit 1
 fi
 
-if [ $uname_arch = 'x86_64' ]; then
+if [ $uname_arch = 'x86_64' -o $uname_arch = 'amd64' ]; then
   arch_name='x64'
-elif [ $uname_arch = 'x86_32' ]; then
+elif [ $uname_arch = 'x86_32' -o $uname_arch = 'i686'
+                              -o $uname_arch = 'i386' ]; then
   arch_name='ia32'
 else
   echo "Architecture not supported: $uname_arch"


### PR DESCRIPTION
We want to interpret the output of `uname -m`, and we currently miss some common values.  Add `amd64` and `i386` in addtion to the `i686` of https://github.com/pagespeed/ngx_pagespeed/pull/122
