### PR TITLE
guard against server only options being configured at location scope

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -419,8 +419,7 @@ ps_configure(ngx_conf_t* cf,
 
   if (option_level == PsConfigure::kLocation && n_args > 1) {
     if (ps_is_global_only_option(args[0])) {
-      return const_cast<char*>(
-          "Option can not be set at location scope");
+      return const_cast<char*>("Option can not be set at location scope");
     }
   }
 


### PR DESCRIPTION
guard against server only options being configured at location scope
this introduces a duplicated list of server-level-only options from mod_instaweb.cc, 
which is a short term solution and should be removed later on

this should fix https://github.com/pagespeed/ngx_pagespeed/issues/99
