### PR TITLE
experiments: support RunExperiment

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -981,7 +981,7 @@ bool ps_determine_request_options(
 bool ps_set_furious_state_and_cookie(ngx_http_request_t* r,
                                      ps_request_ctx_t* ctx,
                                      net_instaweb::RewriteOptions* options,
-                                     const StringPiece host) {
+                                     const StringPiece& host) {
   CHECK(options->running_furious());
   ps_srv_conf_t* cfg_s = ps_get_srv_config(r);
   bool need_cookie = cfg_s->server_context->furious_matcher()->


### PR DESCRIPTION
Before the experiment code was just setting the need_to_store_experiment_data
option but nothing was looking at that option.  Rewrote the code, basing it on
InstawebContext::SetFuriousStateAndCookie, in order to actually set the cookie
to support the experiment.  There are tests for this functionality, but we're
waiting on issue #40 to be able to run them.

Manual testing (with line wrapping):

```
$ curl -s -D- http://localhost:8050/mod_pagespeed_example/ | grep GFURIOUS
Set-Cookie: _GFURIOUS=1; Expires=Fri, 01 Feb 2013 21:38:31 GMT;
            Domain=.localhost; Path=/

$ curl -s -D- http://localhost:8050/mod_pagespeed_example/ | grep GFURIOUS
Set-Cookie: _GFURIOUS=2; Expires=Fri, 01 Feb 2013 21:42:56 GMT;
            Domain=.localhost; Path=/
```

And it responds properly on receiving the cookie, although it did that before
this change too.
