### PR TITLE
readme: support experiment resource urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ In every server block where pagespeed is enabled add:
 
     # This is a temporary workaround that ensures requests for pagespeed
     # optimized resources go to the pagespeed handler.
-    location ~ "\.pagespeed\.[a-z]{2}\.[^.]{10}\.[^.]+" { }
+    location ~ "\.pagespeed\.([a-z]\.)?[a-z]{2}\.[^.]{10}\.[^.]+" { }
     location ~ "^/ngx_pagespeed_static/" { }
     location ~ "^/ngx_pagespeed_beacon$" { }
 


### PR DESCRIPTION
A normal .pagespeed. url looks like:

```
256x192vPuzzle.jpg.pagespeed.ic.alA0AdlR-2.jpg
```

If someone turns on RunExperiment, however, we generate urls like:

```
256x192vPuzzle.jpg.pagespeed.a.ic.alA0AdlR-2.jpg
256x192vPuzzle.jpg.pagespeed.b.ic.alA0AdlR-2.jpg
```

The new section is always a single letter between a and z.  We need to catch
these and pass them through to PageSpeed.
