### PR TITLE
config: explictily link in the math library

### DIFF
--- a/config
+++ b/config
@@ -94,7 +94,7 @@ else
     $psol_library_dir/libapr.a"
 fi
 
-pagespeed_libs="-lstdc++ $psol_library_binaries -lrt -pthread"
+pagespeed_libs="-lstdc++ $psol_library_binaries -lrt -pthread -lm"
 ngx_feature_libs="$pagespeed_libs"
 ngx_feature_test="
   GoogleString output_buffer;


### PR DESCRIPTION
On some platforms we apparently need to explicitly link in the math library in order to get `log@@GLIBC_...` and `floor@@GLIBC_...`.  See [here](https://groups.google.com/forum/#!topic/ngx-pagespeed-discuss/DmLCG14prKg) and [here](https://github.com/pagespeed/ngx_pagespeed/pull/189#issuecomment-15359680).
