### PR TITLE
options: default to core filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ use" below, add this to the top of your configuration:
 In your `nginx.conf`, add to the main or server block:
 
     pagespeed on;
-    pagespeed RewriteLevel CoreFilters;
 
     # needs to exist and be writable by nginx
     pagespeed FileCachePath /var/ngx_pagespeed_cache;

--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -162,7 +162,9 @@ void NgxRewriteDriverFactory::SetupCaches(ServerContext* server_context) {
 }
 
 RewriteOptions* NgxRewriteDriverFactory::NewRewriteOptions() {
-  return new NgxRewriteOptions();
+  NgxRewriteOptions* options = new NgxRewriteOptions();
+  options->SetRewriteLevel(RewriteOptions::kCoreFilters);
+  return options;
 }
 
 

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -72,7 +72,6 @@ check_simple mkdir "$TEST_TMP"
 FILE_CACHE="$TEST_TMP/file-cache/"
 check_simple mkdir "$FILE_CACHE"
 
-
 # set up the config file for the test
 PAGESPEED_CONF="$TEST_TMP/pagespeed_test.conf"
 PAGESPEED_CONF_TEMPLATE="$this_dir/pagespeed_test.conf.template"
@@ -120,6 +119,19 @@ set -- "$PRIMARY_HOSTNAME"
 source $SYSTEM_TEST_FILE
 
 # nginx-specific system tests
+
+start_test Check for correct default X-Page-Speed header format.
+OUT=$($WGET_DUMP $EXAMPLE_ROOT/combine_css.html)
+check_from "$OUT" egrep -q \
+  '^X-Page-Speed: [0-9]+[.][0-9]+[.][0-9]+[.][0-9]+-[0-9]+'
+
+start_test pagespeed is defaulting to more than PassThrough
+fetch_until $TEST_ROOT/bot_test.html 'grep -c \.pagespeed\.' 2
+
+
+
+
+
 
 # When we allow ourself to fetch a resource because the Host header tells us
 # that it is one of our resources, we should be fetching it from ourself.

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -31,9 +31,6 @@ http {
 
     pagespeed on;
 
-    pagespeed RewriteLevel CoreFilters;
-    pagespeed EnableFilters insert_ga,trim_urls;
-
     #pagespeed CacheFlushPollIntervalSec 1;
 
     #pagespeed RunExperiment on;


### PR DESCRIPTION
Don't make people write `pagespeed RewriteLevel CoreFilters` in their config.  We should have filters be on by default, like in apache, and people should have to intentionally turn them off.
