### PR TITLE
system-test: shard domain

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -431,11 +431,6 @@ const char* const global_only_options[] = {
   "TrackOriginalContentLength",
   "UsePerVHostStatistics",
   "XHeaderValue",
-  "CustomFetchHeader",
-  "MapOriginDomain",
-  "MapProxyDomain",
-  "MapRewriteDomain",
-  "ShardDomain",
   "LoadFromFile",
   "LoadFromFileMatch",
   "LoadFromFileRule",
@@ -477,7 +472,8 @@ char* ps_configure(ngx_conf_t* cf,
 
   if (option_level == PsConfigure::kLocation && n_args > 1) {
     if (ps_is_global_only_option(args[0])) {
-      return const_cast<char*>("Option can not be set at location scope");
+      return string_piece_to_pool_string(cf->pool, net_instaweb::StrCat(
+          "\"", args[0], "\" cannot be set at location scope"));
     }
   }
 

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -452,4 +452,10 @@ sleep .1
 OUT=$($FETCH_CMD)
 check_not_from "$OUT" fgrep "<style>"
 
+WGET_ARGS=""
+start_test ModPagespeedShardDomain directive in location block
+fetch_until -save $TEST_ROOT/shard/shard.html 'grep -c \.pagespeed\.' 4
+check [ $(grep -ce href=\"http://shard1 $FETCH_FILE) = 2 ];
+check [ $(grep -ce href=\"http://shard2 $FETCH_FILE) = 2 ];
+
 check_failures_and_exit

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -188,6 +188,12 @@ http {
       }
     }
 
+    location /mod_pagespeed_test/shard/ {
+      pagespeed ShardDomain "localhost:@@PRIMARY_PORT@@" shard1,shard2;
+      pagespeed RewriteLevel PassThrough;
+      pagespeed EnableFilters extend_cache;
+    }
+
     pagespeed EnableFilters remove_comments;
 
     #charset koi8-r;


### PR DESCRIPTION
- Test ShardDomain
- Improve error message when options cannot be set at location scope
  - Used to say `"pagespeed" directive Option cannot be set at location
    scope`, now says `"pagespeed" directive "ShardDomain" cannot be set
    at location scope`.
- Marked `CustomFetchHeader`, `MapOriginDomain`, `MapProxyDomain`,
  `MapRewriteDomain`, and `ShardDomain` as legal to set in location
  blocks.  In `mod_instaweb.cc` they're listed under `All two parameter
  options that are allowed in <Directory> blocks`.
