### PR TITLE
system-test: support FetchProxy and test MapProxyDomain for CDNs

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -658,16 +658,18 @@ char* ps_merge_srv_conf(ngx_conf_t* cf, void* parent, void* child) {
   delete cfg_s->options;
   cfg_s->options = NULL;
 
-  // Validate FileCachePath
-  net_instaweb::GoogleMessageHandler handler;
-  const char* file_cache_path =
-      cfg_s->server_context->config()->file_cache_path().c_str();
-  if (file_cache_path[0] == '\0') {
-    return const_cast<char*>("FileCachePath must be set");
-  } else if (!cfg_m->driver_factory->file_system()->IsDir(
-      file_cache_path, &handler).is_true()) {
-    return const_cast<char*>(
-        "FileCachePath must be an nginx-writeable directory");
+  if (cfg_s->server_context->global_options()->enabled()) {
+    // Validate FileCachePath
+    net_instaweb::GoogleMessageHandler handler;
+    const char* file_cache_path =
+        cfg_s->server_context->config()->file_cache_path().c_str();
+    if (file_cache_path[0] == '\0') {
+      return const_cast<char*>("FileCachePath must be set");
+    } else if (!cfg_m->driver_factory->file_system()->IsDir(
+        file_cache_path, &handler).is_true()) {
+      return const_cast<char*>(
+          "FileCachePath must be an nginx-writeable directory");
+    }
   }
 
   return NGX_CONF_OK;
@@ -1282,6 +1284,11 @@ CreateRequestContext::Response ps_create_request_context(
     ngx_http_request_t* r, bool is_resource_fetch) {
   ps_srv_conf_t* cfg_s = ps_get_srv_config(r);
 
+  if (!cfg_s->server_context->global_options()->enabled()) {
+    // Not enabled for this server block.
+    return CreateRequestContext::kPagespeedDisabled;
+  }
+
   GoogleString url_string = ps_determine_url(r);
 
   net_instaweb::GoogleUrl url(url_string);
@@ -1398,6 +1405,8 @@ CreateRequestContext::Response ps_create_request_context(
   }
 
   if (!options->enabled()) {
+    // Disabled via query params or request headers.
+
     ctx->base_fetch->Done(false);  // Not passed to Proxy/ResourceFetch yet.
     ps_release_request_context(ctx);
     return CreateRequestContext::kPagespeedDisabled;

--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -110,25 +110,14 @@ Hasher* NgxRewriteDriverFactory::NewHasher() {
 }
 
 UrlFetcher* NgxRewriteDriverFactory::DefaultUrlFetcher() {
-  return new WgetUrlFetcher;
+  CHECK(false) << "Nothing should still be using DefaultUrlFetcher()";
+  return NULL;
 }
 
 UrlAsyncFetcher* NgxRewriteDriverFactory::DefaultAsyncUrlFetcher() {
-  const char* fetcher_proxy = "";
-  if (main_conf_ != NULL) {
-    fetcher_proxy = main_conf_->fetcher_proxy().c_str();
-  }
-
-  net_instaweb::UrlAsyncFetcher* fetcher =
-      new net_instaweb::SerfUrlAsyncFetcher(
-          fetcher_proxy,
-          NULL,
-          thread_system(),
-          statistics(),
-          timer(),
-          2500,
-          message_handler());
-  return fetcher;
+  CHECK(false) << "Don't use DefaultAsyncUrlFatcher() because then you "
+               << "don't get per-server-block fetcher configuration";
+  return NULL;
 }
 
 MessageHandler* NgxRewriteDriverFactory::DefaultHtmlParseMessageHandler() {

--- a/src/ngx_server_context.h
+++ b/src/ngx_server_context.h
@@ -72,6 +72,8 @@ class NgxServerContext : public SystemServerContext {
   // These are non-NULL if we have per-vhost stats.
   scoped_ptr<RewriteStats> local_rewrite_stats_;
 
+  scoped_ptr<UrlAsyncFetcher> fetcher_;
+
   DISALLOW_COPY_AND_ASSIGN(NgxServerContext);
 };
 

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -867,4 +867,60 @@ rm -f $CSS_FILE
 
 run_post_cache_flush
 
+start_test MapProxyDomain for CDN setup
+# Test transitive ProxyMapDomain.  In this mode we have three hosts: cdn,
+# proxy, and origin.  Proxy runs pagespeed and fetches resources from origin,
+# optimizes them, and rewrites them to CDN for serving. The CDN is dumb and
+# has no caching so simply proxies all requests to proxy.  Origin serves out
+# images only.
+echo "Rewrite HTML with reference to proxyable image on CDN."
+WGET_ARGS=""
+URL="http://proxy.pm.example.com/transitive_proxy.html"
+PDT_STATSDIR=$TEMPDIR/stats
+rm -rf $PDT_STATSDIR
+mkdir -p $PDT_STATSDIR
+PDT_OLDSTATS=$PDT_STATSDIR/blocking_rewrite_stats.old
+PDT_NEWSTATS=$PDT_STATSDIR/blocking_rewrite_stats.new
+PDT_PROXY_STATS_URL=http://proxy.pm.example.com/ngx_pagespeed_statistics
+
+http_proxy=$SECONDARY_HOSTNAME \
+  $WGET_DUMP $PDT_PROXY_STATS_URL > $PDT_OLDSTATS
+
+# The image should be proxied from origin, compressed, and rewritten to cdn.
+http_proxy=$SECONDARY_HOSTNAME \
+  fetch_until -save -recursive $URL \
+  'fgrep -c cdn.pm.example.com/external/xPuzzle.jpg.pagespeed.ic' 1
+check_file_size "${OUTDIR}/xPuzzle*" -lt 241260
+
+# Make sure that the file was only rewritten once.
+http_proxy=$SECONDARY_HOSTNAME \
+  $WGET_DUMP $PDT_PROXY_STATS_URL > $PDT_NEWSTATS
+check_stat $PDT_OLDSTATS $PDT_NEWSTATS image_rewrites 1
+
+# The js should be fetched locally and inlined.
+http_proxy=$SECONDARY_HOSTNAME \
+  fetch_until -save -recursive $URL 'fgrep -c getElementsByTagName' 1
+
+# Save the image URL so we can try to reconstruct it later.
+PDT_IMG_URL=`egrep -o \".*xPuzzle.*\.pagespeed.*\" $FETCH_FILE | \
+  sed -e 's/\"//g'`
+
+# This function will be called after the cache is flushed to test
+# reconstruction.
+function map_proxy_domain_cdn_reconstruct() {
+  rm -rf $PDT_STATSDIR
+  mkdir -p $PDT_STATSDIR
+  http_proxy=$SECONDARY_HOSTNAME \
+    $WGET_DUMP $PDT_PROXY_STATS_URL > $PDT_OLDSTATS
+  echo "Make sure we can reconstruct the image."
+  http_proxy=$SECONDARY_HOSTNAME \
+    check wget -O $TEMPDIR/tp.jpg $PDT_IMG_URL
+  check_file_size $TEMPDIR/tp.jpg -lt 241260
+  # Double check that we actually reconstructed.
+  http_proxy=$SECONDARY_HOSTNAME \
+    $WGET_DUMP $PDT_PROXY_STATS_URL > $PDT_NEWSTATS
+  check_stat $PDT_OLDSTATS $PDT_NEWSTATS image_rewrites 1
+}
+on_cache_flush map_proxy_domain_cdn_reconstruct
+
 check_failures_and_exit

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -194,6 +194,71 @@ http {
     add_header Cache-Control no-transform;
   }
 
+  # The following three VHosts are created for mod_pagespeed issue 599.
+  #   Create three sites for a MapProxyDomain experiment. The sites are:
+  # cdn: forwards requests to proxy.
+  # proxy: runs pagespeed, and optimizes data from origin.
+  # origin: a normal website that is potentially external to proxy.
+  server {
+    # The CDN in our example which simply forwards requests to the proxy.
+
+    listen @@SECONDARY_PORT@@;
+    server_name cdn.pm.example.com;
+
+    # mod_pagespeed would say "unplugged" here, but in ngx_pagespeed off means
+    # off.
+    pagespeed off;
+
+    # Point the docroot somewhere useless so that we know we're not fetching
+    # from the CDN's filesystem. Note that in particular we are not attempting
+    # to run CGI scripts.
+    root "@@SERVER_ROOT@@/mod_pagespeed_example/cgi";
+
+    # Use a proxy to reach our VirtualHost servers.
+    location /external/ {
+      # nginx doesn't seem to have an equivalent of ProxyRemote, but we can fake
+      # it.
+      proxy_pass http://localhost:@@SECONDARY_PORT@@/external/;
+      proxy_set_header Host proxy.pm.example.com;
+    }
+  }
+
+  server {
+    # The proxy that runs pagespeed and can proxy data from origin. When the CDN
+    # requests proxied data from the proxy the proxy knows to fetch it from the
+    # origin server.
+
+    listen @@SECONDARY_PORT@@;
+    server_name proxy.pm.example.com;
+    root "@@SERVER_ROOT@@/mod_pagespeed_test/";
+
+    # The usual cache location so that it gets cleared for on_cache_flush tests.
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+
+    # We have to fetch through our localhost proxy to get to our other vhosts.
+    pagespeed FetchProxy "localhost:@@SECONDARY_PORT@@";
+
+    # Origin resources should be optimized and hosted on proxy/external but
+    # rewritten to cdn/external.
+    pagespeed Domain proxy.pm.example.com;
+    pagespeed MapProxyDomain proxy.pm.example.com/external
+                             origin.pm.example.com
+                             cdn.pm.example.com/external;
+    pagespeed RewriteLevel CoreFilters;
+    pagespeed RewriteDeadlinePerFlushMs -1;
+  }
+
+  server {
+    # The origin that serves the images to be proxied (Puzzle.jpg)
+
+    listen @@SECONDARY_PORT@@;
+    server_name origin.pm.example.com;
+    root "@@SERVER_ROOT@@/mod_pagespeed_example/images";
+
+    # Again, mod_pagespeed would say "unplugged" here.
+    pagespeed off;
+  }
+
   server {
     listen       @@PRIMARY_PORT@@;
     server_name  localhost;


### PR DESCRIPTION
- Test MapProxyDomain for CDN setup
- Only validate FileCachePath in server blocks where pagespeed is enabled.
- Sort-circuit in ps_create_request_context when disabled.
- Support FetchProxy option.
  - This required moving fetcher initialization to the ServerContext from the
    RewriteDriverFactory.
