### PR TITLE
statistics: check that statistics work and are not externally accessible

### DIFF
--- a/src/ngx_base_fetch.h
+++ b/src/ngx_base_fetch.h
@@ -45,6 +45,8 @@ extern "C" {
 
 #include "ngx_pagespeed.h"
 
+#include "ngx_server_context.h"
+
 #include "net/instaweb/http/public/async_fetch.h"
 #include "net/instaweb/http/public/headers.h"
 #include "net/instaweb/util/public/string.h"
@@ -54,6 +56,7 @@ namespace net_instaweb {
 class NgxBaseFetch : public AsyncFetch {
  public:
   NgxBaseFetch(ngx_http_request_t* r, int pipe_fd,
+               NgxServerContext* server_context,
                const RequestContextPtr& request_ctx);
   virtual ~NgxBaseFetch();
 
@@ -113,6 +116,7 @@ class NgxBaseFetch : public AsyncFetch {
 
   ngx_http_request_t* request_;
   GoogleString buffer_;
+  NgxServerContext* server_context_;
   bool done_called_;
   bool last_buf_sent_;
   int pipe_fd_;

--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -1374,6 +1374,7 @@ CreateRequestContext::Response ps_create_request_context(
   // the BaseFetch ourselves.
   ctx->base_fetch = new net_instaweb::NgxBaseFetch(
       r, file_descriptors[1],
+      cfg_s->server_context,
       net_instaweb::RequestContextPtr(new net_instaweb::NgxRequestContext(
           cfg_s->server_context->thread_system()->NewMutex(), r)));
 

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -230,6 +230,16 @@ http {
     pagespeed MapProxyDomain localhost:@@PRIMARY_PORT@@/pss_images
                              http://ref.pssdemos.com/filter/images;
 
+    location /ngx_pagespeed_statistics {
+      allow 127.0.0.1;
+      deny all;
+    }
+
+    location /ngx_pagespeed_message {
+      allow 127.0.0.1;
+      deny all;
+    }
+
     location ~ \.php$ {
       fastcgi_param SCRIPT_FILENAME $request_filename;
       fastcgi_param QUERY_STRING $query_string;


### PR DESCRIPTION
- Add tests for statistics.
- We weren't increasing resource_404_count on 404s.
  - This required giving `NgxBaseFetch` a `NgxServerContext` pointer.
- /ngx_pagespeed_statistics was publically available.
- Made a pass over the readme to add a new configuration option and fixed up
  serveral things that were out of date while I was there.

Fixes #248.
