### PR TITLE
Use ngx_thread_system in NgxRewriteDriverFactory.

### DIFF
--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -71,7 +71,7 @@ const char kShutdownCount[] = "child_shutdown_count";
 }  // namespace
 
 NgxRewriteDriverFactory::NgxRewriteDriverFactory()
-    : SystemRewriteDriverFactory(new NgxThreadSystem()),
+    : SystemRewriteDriverFactory(ngx_thread_system_ = new NgxThreadSystem),
       // TODO(oschaaf): mod_pagespeed ifdefs this:
       shared_mem_runtime_(new ngx::PthreadSharedMem()),
       main_conf_(NULL),
@@ -266,7 +266,7 @@ void NgxRewriteDriverFactory::StartThreads() {
   if (threads_started_) {
     return;
   }
-  static_cast<NgxThreadSystem*>(thread_system())->PermitThreadStarting();
+  ngx_thread_system_->PermitThreadStarting();
   // TODO(jefftk): use a native nginx timer instead of running our own thread.
   // See issue #111.
   SchedulerThread* thread = new SchedulerThread(thread_system(), scheduler());

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -40,9 +40,10 @@ extern "C" {
 namespace net_instaweb {
 
 class AbstractSharedMem;
-class NgxServerContext;
 class NgxMessageHandler;
 class NgxRewriteOptions;
+class NgxServerContext;
+class NgxThreadSystem;
 class NgxUrlAsyncFetcher;
 class SharedCircularBuffer;
 class SharedMemRefererStatistics;
@@ -179,6 +180,7 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   }
 
  private:
+  NgxThreadSystem* ngx_thread_system_;
   Timer* timer_;
   scoped_ptr<AbstractSharedMem> shared_mem_runtime_;
 


### PR DESCRIPTION
PSOL has:

```
RewriteDriverFactory::RewriteDriverFactory(ThreadSystem* thread_system) {
#ifdef NDEBUG
  // For release binaries, use the thread-system directly.
  thread_system_.reset(thread_system);
#else
  // When compiling for debug, interpose a layer that CHECKs for clean mutex
  // semantics.
  thread_system_.reset(new CheckingThreadSystem(thread_system));
#endif
  Init();
}
```

Which means that when you compile it with with `Release=DEBUG` then `static_cast<NgxThreadSystem*>(thread_system())` is no longer valid and so you get #237 : "check failed: may start threads".

By adding a local `ngx_thread_system_` to `NgxRewriteDriverFactory` we can still call through to `PermitThreadStarting` even though all other calls using `thread_system()` will go via a `CheckingThreadSystem`.
