### PR TITLE
thread-system: hold on to the NgxThreadSystem for PermitThreadStarting()

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -42,6 +42,7 @@ extern "C" {
 #include "ngx_rewrite_driver_factory.h"
 #include "ngx_rewrite_options.h"
 #include "ngx_server_context.h"
+#include "ngx_thread_system.h"
 
 #include "apr_time.h"
 
@@ -590,7 +591,8 @@ void* ps_create_main_conf(ngx_conf_t* cf) {
   net_instaweb::NgxRewriteOptions::Initialize();
   net_instaweb::NgxRewriteDriverFactory::Initialize();
 
-  cfg_m->driver_factory = new net_instaweb::NgxRewriteDriverFactory();
+  cfg_m->driver_factory = new net_instaweb::NgxRewriteDriverFactory(
+      new net_instaweb::NgxThreadSystem());
   ps_set_conf_cleanup_handler(cf, ps_cleanup_main_conf, cfg_m);
   return cfg_m;
 }

--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -70,8 +70,10 @@ const char kShutdownCount[] = "child_shutdown_count";
 
 }  // namespace
 
-NgxRewriteDriverFactory::NgxRewriteDriverFactory()
-    : SystemRewriteDriverFactory(new NgxThreadSystem()),
+NgxRewriteDriverFactory::NgxRewriteDriverFactory(
+    NgxThreadSystem* ngx_thread_system)
+    : SystemRewriteDriverFactory(ngx_thread_system),
+      ngx_thread_system_(ngx_thread_system),
       // TODO(oschaaf): mod_pagespeed ifdefs this:
       shared_mem_runtime_(new ngx::PthreadSharedMem()),
       main_conf_(NULL),
@@ -266,7 +268,7 @@ void NgxRewriteDriverFactory::StartThreads() {
   if (threads_started_) {
     return;
   }
-  static_cast<NgxThreadSystem*>(thread_system())->PermitThreadStarting();
+  ngx_thread_system_->PermitThreadStarting();
   // TODO(jefftk): use a native nginx timer instead of running our own thread.
   // See issue #111.
   SchedulerThread* thread = new SchedulerThread(thread_system(), scheduler());

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -40,9 +40,10 @@ extern "C" {
 namespace net_instaweb {
 
 class AbstractSharedMem;
-class NgxServerContext;
 class NgxMessageHandler;
 class NgxRewriteOptions;
+class NgxServerContext;
+class NgxThreadSystem;
 class NgxUrlAsyncFetcher;
 class SharedCircularBuffer;
 class SharedMemRefererStatistics;
@@ -56,9 +57,8 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
  public:
   static const char kStaticAssetPrefix[];
 
-  // main_conf will have only options set in the main block.  It may be NULL,
-  // and we do not take ownership.
-  explicit NgxRewriteDriverFactory();
+  // We take ownership of the thread system.
+  explicit NgxRewriteDriverFactory(NgxThreadSystem* ngx_thread_system);
   virtual ~NgxRewriteDriverFactory();
   virtual Hasher* NewHasher();
   virtual UrlFetcher* DefaultUrlFetcher();
@@ -179,6 +179,7 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   }
 
  private:
+  NgxThreadSystem* ngx_thread_system_;
   Timer* timer_;
   scoped_ptr<AbstractSharedMem> shared_mem_runtime_;
 


### PR DESCRIPTION
Retry of #277 , which I was too hasty in merging.  Fixes the possibly undefined behavior in the initialization list that we had before.

PSOL has:

```
RewriteDriverFactory::RewriteDriverFactory(ThreadSystem* thread_system) {
#ifdef NDEBUG
  // For release binaries, use the thread-system directly.
  thread_system_.reset(thread_system);
#else
  // When compiling for debug, interpose a layer that CHECKs for clean mutex
  // semantics.
  thread_system_.reset(new CheckingThreadSystem(thread_system));
#endif
  Init();
}
```

Which means that when you compile it with with `Release=DEBUG` then `static_cast<NgxThreadSystem*>(thread_system())` is no longer valid and so you get #237 : "check failed: may start threads".

By adding a local `ngx_thread_system_` to `NgxRewriteDriverFactory` we can still call through to `PermitThreadStarting` even though all other calls using `thread_system()` will go via a `CheckingThreadSystem`.
