### PR TITLE
Some code clean up

### DIFF
--- a/src/ngx_pagespeed.h
+++ b/src/ngx_pagespeed.h
@@ -34,6 +34,7 @@ extern "C" {
 }
 
 #include "base/logging.h"
+#include "net/instaweb/http/public/request_headers.h"
 #include "net/instaweb/http/public/response_headers.h"
 #include "net/instaweb/util/public/string_util.h"
 
@@ -75,6 +76,15 @@ StringPiece str_to_string_piece(ngx_str_t s);
 // Allocate memory out of the pool for the string piece, and copy the contents
 // over.  Returns NULL if we can't get memory.
 char* string_piece_to_pool_string(ngx_pool_t* pool, StringPiece sp);
+
+void copy_request_headers_from_ngx(
+    const ngx_http_request_t *r,
+    net_instaweb::RequestHeaders * headers);
+
+void copy_response_headers_from_ngx(
+    const ngx_http_request_t *r, 
+    net_instaweb::ResponseHeaders *headers);
+
 ngx_int_t copy_response_headers_to_ngx(
     ngx_http_request_t* r,
     const net_instaweb::ResponseHeaders& pagespeed_headers);


### PR DESCRIPTION
- NgxBaseFetch:
  - use AbstractMutest instead of pthread_mutex_t
  - use AtomicInt32 type as reference
  - move Headers related function to globe ngx_psol namespace
- ps_create_request_context:
  - determine options before create NgxBaseFetch.
  - fixed possiable pipe fd leakage
  - fixed costum_options memory leak
- inline some functions
