### PR TITLE
serf: force threaded fetches

### DIFF
--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -138,7 +138,7 @@ UrlAsyncFetcher* NgxRewriteDriverFactory::DefaultAsyncUrlFetcher() {
     ngx_url_async_fetcher_ = fetcher;
     return fetcher;
   } else {
-    net_instaweb::UrlAsyncFetcher* fetcher =
+    net_instaweb::SerfUrlAsyncFetcher* fetcher =
         new net_instaweb::SerfUrlAsyncFetcher(
             fetcher_proxy,
             NULL,
@@ -147,6 +147,8 @@ UrlAsyncFetcher* NgxRewriteDriverFactory::DefaultAsyncUrlFetcher() {
             timer(),
             2500,
             message_handler());
+    // Make sure we don't block the nginx event loop
+    fetcher->set_force_threaded(true);
     return fetcher;
   }
 }


### PR DESCRIPTION
This should prevent stalling the ngx event loop when using the serf fetcher, and really speeds up  response times for me when there are a lot of uncached resources to fetch. 

Possibly fixes another cause of hanging pages by eliminating possible deadlock situations which can only be resolved by timeouts.

Possibly related: https://github.com/pagespeed/ngx_pagespeed/issues/325
