### PR TITLE
memcached: temporary workaround to fix handling HUP signals

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -546,6 +546,16 @@ void ps_cleanup_srv_conf(void* data) {
   // from being executed
 
   if (!factory_deleted && cfg_s->server_context != NULL) {
+    // We never start threads in the master process, but with with memcached on,
+    // it looks like a new thread is started during destruction of the factory.
+    // As a temporary workaround, we permit threads to start here.
+    net_instaweb::NgxRewriteDriverFactory* factory =
+        dynamic_cast<net_instaweb::NgxRewriteDriverFactory*>(
+            cfg_s->server_context->factory());
+    if (!factory->ngx_thread_system()->may_start_threads()) {
+      factory->ngx_thread_system()->PermitThreadStarting();
+    }
+
     delete cfg_s->server_context->factory();
     factory_deleted = true;
   }

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -170,6 +170,10 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
     use_native_fetcher_ = x;
   }
 
+  NgxThreadSystem* ngx_thread_system() {
+    return ngx_thread_system_;
+  }
+
   // We use a beacon handler to collect data for critical images,
   // css, etc., so filters should be configured accordingly.
   //

--- a/src/ngx_thread_system.h
+++ b/src/ngx_thread_system.h
@@ -41,7 +41,7 @@ class NgxThreadSystem : public PthreadThreadSystem {
   // right after forking, and CHECK-fail if something tries to start a thread
   // before then.
   void PermitThreadStarting();
-
+  bool may_start_threads() { return may_start_threads_; }
  protected:
   virtual void BeforeThreadRunHook();
 


### PR DESCRIPTION
Temporarily allow starting new threads during factory destruction in
the master process. Apparently we start a new thread to execute
scheduled cleanup code.

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/364
