### PR TITLE
keepalive-test: Test that we handle keep-alive requests OK

### DIFF
--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -391,6 +391,31 @@ http {
   }
 
   server {
+    listen @@SECONDARY_PORT@@;
+    server_name keepalive.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+
+    pagespeed RewriteLevel CoreFilters;
+
+    error_log "@@TEST_TMP@@/ka-error.log" info;
+    index index.html;
+
+    location ~ "\.pagespeed\.([a-z]\.)?[a-z]{2}\.[^.]{10}\.[^.]+" {
+      add_header "" "";
+    }
+
+    location /ngx_pagespeed_statistics {
+      allow 127.0.0.1;
+      deny all;
+    }
+
+    location /ngx_pagespeed_message {
+      allow 127.0.0.1;
+      deny all;
+    }
+  }
+
+  server {
     listen       @@PRIMARY_PORT@@;
     server_name  localhost;
     pagespeed FileCachePath "@@FILE_CACHE@@";


### PR DESCRIPTION
Add a keepalive test which is repeated 100 times, with us both
behind the gzip filter and directly behind nginx's output filter.
The reason for that is that modules running after us can mask
our errors, this at least tests the most used ones.

This CL adds a failure to the expected failures, as currently,
this tests gives suspicious messages in nginx's error.log:
"client prematurely closed connection while sending response to client"

We should probably also test other code paths, like .pagespeed.
resources and the beacon with post requests as well. If this approach
is generally ok, I can proceed to add those as well.
