### PR TITLE
Getting it working with mod_pagespeed (r3061).

### DIFF
--- a/src/ngx_fetch.h
+++ b/src/ngx_fetch.h
@@ -35,7 +35,7 @@ extern "C" {
 #include "net/instaweb/util/public/basictypes.h"
 #include "net/instaweb/util/public/pool.h"
 #include "net/instaweb/util/public/string.h"
-#include "net/instaweb/http/public/url_pollable_async_fetcher.h"
+#include "net/instaweb/http/public/url_async_fetcher.h"
 #include "net/instaweb/http/public/response_headers.h"
 #include "net/instaweb/http/public/response_headers_parser.h"
 

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -128,12 +128,14 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   // one server context (global or VirtualHost) enables statistics.
   Statistics* MakeGlobalSharedMemStatistics(bool logging,
                                             int64 logging_interval_ms,
+                                            const int64 max_logfile_size_kb,
                                             const GoogleString& logging_file);
 
   // Creates and ::Initializes a shared memory statistics object.
   SharedMemStatistics* AllocateAndInitSharedMemStatistics(
       const StringPiece& name, const bool logging,
-      const int64 logging_interval_ms, const GoogleString& logging_file);
+      const int64 logging_interval_ms, const int64 max_logfile_size_kb,
+      const GoogleString& logging_file);
 
   NgxMessageHandler* ngx_message_handler() { return ngx_message_handler_; }
   void set_main_conf(NgxRewriteOptions* main_conf) {  main_conf_ = main_conf; }

--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -37,7 +37,8 @@ namespace net_instaweb {
 
 RewriteOptions::Properties* NgxRewriteOptions::ngx_properties_ = NULL;
 
-NgxRewriteOptions::NgxRewriteOptions() {
+NgxRewriteOptions::NgxRewriteOptions(ThreadSystem* thread_system)
+    : SystemRewriteOptions(thread_system) {
   Init();
 }
 
@@ -51,8 +52,11 @@ void NgxRewriteOptions::AddProperties() {
   // Nothing ngx-specific for now.
 
   MergeSubclassProperties(ngx_properties_);
-  NgxRewriteOptions config;
-  config.InitializeSignaturesAndDefaults();
+  // We create a dummy NgxRewriteOptions object here so that we can
+  // call InitializeSignaturesAndDefaults on it, and in turn get the
+  // global defaults (for say, X-Page-Speed header value) setup correctly.
+  NgxRewriteOptions dummy_config(NULL);
+  dummy_config.InitializeSignaturesAndDefaults();
 }
 
 void NgxRewriteOptions::InitializeSignaturesAndDefaults() {
@@ -231,7 +235,7 @@ NgxRewriteOptions::ParseAndSetOptions(
 }
 
 NgxRewriteOptions* NgxRewriteOptions::Clone() const {
-  NgxRewriteOptions* options = new NgxRewriteOptions();
+  NgxRewriteOptions* options = new NgxRewriteOptions(thread_system());
   options->Merge(*this);
   return options;
 }

--- a/src/ngx_rewrite_options.h
+++ b/src/ngx_rewrite_options.h
@@ -40,7 +40,7 @@ class NgxRewriteOptions : public SystemRewriteOptions {
   static void Initialize();
   static void Terminate();
 
-  NgxRewriteOptions();
+  explicit NgxRewriteOptions(ThreadSystem* thread_system);
   virtual ~NgxRewriteOptions() { }
 
   // args is an array of n_args StringPieces together representing a directive.

--- a/src/ngx_server_context.cc
+++ b/src/ngx_server_context.cc
@@ -86,7 +86,8 @@ void NgxServerContext::CreateLocalStatistics(
           hostname_identifier(),
           config()->statistics_logging_enabled(),
           config()->statistics_logging_interval_ms(),
-          config()->statistics_logging_file());
+          config()->statistics_logging_max_file_size_kb(),
+          config()->statistics_logging_file_prefix());
   split_statistics_.reset(new SplitStatistics(
       ngx_factory_->thread_system(), local_statistics_, global_statistics));
   // local_statistics_ was ::InitStat'd by AllocateAndInitSharedMemStatistics,

--- a/src/ngx_url_async_fetcher.h
+++ b/src/ngx_url_async_fetcher.h
@@ -33,11 +33,11 @@ extern "C" {
 }
 
 #include <vector>
+#include "net/instaweb/http/public/url_async_fetcher.h"
 #include "net/instaweb/util/public/basictypes.h"
 #include "net/instaweb/util/public/pool.h"
 #include "net/instaweb/util/public/string.h"
 #include "net/instaweb/util/public/thread_system.h"
-#include "net/instaweb/http/public/url_pollable_async_fetcher.h"
 
 
 namespace net_instaweb {


### PR DESCRIPTION
Updating trunk-tracking to compile and work with mod_pagespeed svn revision 3061 with 2 small modifications to serf_url_async_fetcher.cc to disable SERF_HTTPS_FETCHING.

Please note that anyone building mod_pagespeed from source will need to
a) edit serf_url_async_fetcher.h to change the line "#define SERF_HTTPS_FETCHING 1" to have 0.
b) edit serf_url_async_fetcher.cc to move the definition of "apr_status_t status = APR_SUCCESS;" on line 265 to be inside the "#if SERF_HTTPS_FETCHING" block (in order to avoid a compilation error for psol/mod_pagespeed).

Highlights of this change:

1) Propagating renaming changes related to
  a) Furious -> Experiment
  b) ModPagespeed -> PageSpeed.
2) UrlPollableAsyncFetcher going away.
3) RewriteOptions now requiring a ThreadSystem parameter for construction.
4) Removing client_property_cache references and usages (since this was removed from mod_pagespeed).
5) Propagating beacon construction changes (where POST requests can now carry the url query param in the request).
6) General fixes for API/test breakages in statistics_logger, fallback property page cache,
