### PR TITLE
caching: Sample proxy_cache_key construction.

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -183,6 +183,7 @@ else
   $NGINX_EXECUTABLE -c $PAGESPEED_CONF >& "$TRACE_FILE"
   if [[ $? -ne 0 ]]; then
     echo "FAIL"
+    cat $TRACE_FILE
     if [[ $(grep -c "unknown directive \"proxy_cache_purge\"" $TRACE_FILE) == 1 ]]; then
       echo "This test requires proxy_cache_purge. One way to do this:"
       echo "Run git clone https://github.com/FRiCKLE/ngx_cache_purge.git"

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -69,9 +69,45 @@ http {
 
     pagespeed off;
 
+    set $ua_dependent_ps_capability_list "";
+    set $bypass_cache 1;
+    if ($http_user_agent ~* "Chrome/|Firefox/|MSIE |Safari|Wget") {
+      # User Agents that support lazyload-images (ll), inline-images (ii) and
+      # defer-javascript (dj).
+      set $ua_dependent_ps_capability_list "ll,ii,dj:";
+      set $bypass_cache 0;
+    }
+    if ($http_user_agent ~*
+        "Chrome/[2][3-9]+\.|Chrome/[[3-9][0-9]+\.|Chrome/[0-9]{3,}\.") {
+      # User Agents that support lazyload-images (ll), inline-images (ii),
+      # defer-javascript (dj), webp (jw) and webp-lossless (ws).
+      set $ua_dependent_ps_capability_list "ll,ii,dj,jw,ws:";
+      set $bypass_cache 0;
+    }
+
+    # All User Agents that represent
+    # 1) mobiles
+    # 2) tablets
+    # 3) desktop browsers that do not have defer-javascript capability at a minimum
+    # are made to go to the pagespeed server directly bypassing the proxy_cache.
+    if ($http_user_agent ~* "Firefox/[1-2]\.|MSIE [5-8]\.") {
+      set $ua_dependent_ps_capability_list "";
+      set $bypass_cache 1;
+    }
+    if ($http_user_agent ~* "Mozilla.*Android.*Mobile*|iPhone|BlackBerry|Opera Mobi|Opera Mini|SymbianOS|UP.Browser|J-PHONE|Profile/MIDP|portalmmm|DoCoMo|Obigo") {
+      # These are Mobile User Agents. We don't cache responses for these.
+      set $ua_dependent_ps_capability_list "";
+      set $bypass_cache 1;
+    }
+    if ($http_user_agent ~* "Android|iPad|TouchPad|Silk-Accelerated|Kindle Fire") {
+      # These are Tablet User Agents. We don't cache responses for these.
+      set $ua_dependent_ps_capability_list "";
+      set $bypass_cache 1;
+    }
+    
     location ~ /purge(/.*) {
       allow all;
-      proxy_cache_purge htmlcache $1$is_args$args;
+      proxy_cache_purge htmlcache $ua_dependent_ps_capability_list$1$is_args$args;
     }
 
     location /mod_pagespeed_test/cachable_rewritten_html/ {
@@ -80,7 +116,8 @@ http {
       proxy_cache htmlcache;
       proxy_ignore_headers Cache-Control;
       add_header X-Cache $upstream_cache_status;
-      proxy_cache_key $uri$is_args$args;
+      proxy_cache_key $ua_dependent_ps_capability_list$uri$is_args$args;
+      proxy_cache_bypass $bypass_cache;
     }
   }
 
@@ -488,7 +525,7 @@ http {
       # in the very first attempt.
       pagespeed RewriteDeadlinePerFlushMs 1;
       pagespeed RewriteLevel PassThrough;
-      pagespeed EnableFilters collapse_whitespace,extend_cache,recompress_images;
+      pagespeed EnableFilters collapse_whitespace,extend_cache,recompress_images,convert_jpeg_to_webp,defer_javascript;
     }
     # uncomment the following two lines if you're testing memcached
     #pagespeed MemcachedServers "localhost:11211";


### PR DESCRIPTION
Adding a nginx conf snippet for constructing a proxy_cache_key based on the UserAgent and expected optimizations for that UserAgent class, bypassing the cache for all other cases. Sample config for downstream-cache proxy_cache_key construction now takes care of 2 classes of UserAgents (expected to get most of the traffic for a site) and also bypasses cache for all other desktop UAs, all mobile UAs and all tablet UAs.

(Fixing the startup phase of the nginx server to put out the original error message in case of failure.)
