### PR TITLE
trunk-tracking: update to r3193

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -2672,11 +2672,8 @@ ngx_int_t ps_init_module(ngx_cycle_t* cycle) {
       // allows statistics to work if ngx_pagespeed gets turned on via
       // .htaccess or query param.
       if ((statistics == NULL) && config->statistics_enabled()) {
-        statistics = cfg_m->driver_factory->MakeGlobalSharedMemStatistics(
-            config->statistics_logging_enabled(),
-            config->statistics_logging_interval_ms(),
-            config->statistics_logging_max_file_size_kb(),
-            config->statistics_logging_file_prefix());
+        statistics = \
+            cfg_m->driver_factory->MakeGlobalSharedMemStatistics(*config);
       }
 
       // The hostname identifier is used by the shared memory statistics

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -125,16 +125,11 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   void SharedCircularBufferInit(bool is_root);
   // Build global shared-memory statistics.  This is invoked if at least
   // one server context (global or VirtualHost) enables statistics.
-  Statistics* MakeGlobalSharedMemStatistics(bool logging,
-                                            int64 logging_interval_ms,
-                                            const int64 max_logfile_size_kb,
-                                            const GoogleString& logging_file);
+  Statistics* MakeGlobalSharedMemStatistics(const NgxRewriteOptions& options);
 
   // Creates and ::Initializes a shared memory statistics object.
   SharedMemStatistics* AllocateAndInitSharedMemStatistics(
-      const StringPiece& name, const bool logging,
-      const int64 logging_interval_ms, const int64 max_logfile_size_kb,
-      const GoogleString& logging_file);
+      const StringPiece& name, const NgxRewriteOptions& options);
 
   NgxMessageHandler* ngx_message_handler() { return ngx_message_handler_; }
   void set_main_conf(NgxRewriteOptions* main_conf) {  main_conf_ = main_conf; }

--- a/src/ngx_server_context.cc
+++ b/src/ngx_server_context.cc
@@ -83,11 +83,7 @@ void NgxServerContext::CreateLocalStatistics(
     Statistics* global_statistics) {
   local_statistics_ =
       ngx_factory_->AllocateAndInitSharedMemStatistics(
-          hostname_identifier(),
-          config()->statistics_logging_enabled(),
-          config()->statistics_logging_interval_ms(),
-          config()->statistics_logging_max_file_size_kb(),
-          config()->statistics_logging_file_prefix());
+          hostname_identifier(), *config());
   split_statistics_.reset(new SplitStatistics(
       ngx_factory_->thread_system(), local_statistics_, global_statistics));
   // local_statistics_ was ::InitStat'd by AllocateAndInitSharedMemStatistics,

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1032,7 +1032,7 @@ NUM_INITIAL_FLUSHES_C=$(cache_flush_count_scraper c)
 # Now change the file to $COLOR1.
 echo ".class myclass { color: $COLOR1; }" > "$CSS_FILE"
 
-# We expect to have a stale cache for 5 minutes, so the result should stay
+# We expect to have a stale cache for 5 seconds, so the result should stay
 # $COLOR0.  This only works because we have only one worker process.  If we had
 # more than one then the worker process handling this request might be different
 # than the one that got the previous one, and it wouldn't be in cache.
@@ -1542,8 +1542,11 @@ BEACON_PATH=$(sed -n "s/${CALL_PAT}${CAPTURE_ARG}/\1/p" $FETCH_FILE)
 ESCAPED_URL=$(sed -n "s/${CALL_PAT}${SKIP_ARG}${CAPTURE_ARG}/\1/p" $FETCH_FILE)
 OPTIONS_HASH=$( \
   sed -n "s/${CALL_PAT}${SKIP_ARG}${SKIP_ARG}${CAPTURE_ARG}/\1/p" $FETCH_FILE)
+NONCE=$( \
+  sed -n "s/${CALL_PAT}${SKIP_ARG}${SKIP_ARG}${SKIP_ARG}${CAPTURE_ARG}/\1/p" \
+  $FETCH_FILE)
 BEACON_URL="http://${HOSTNAME}${BEACON_PATH}?url=${ESCAPED_URL}"
-BEACON_DATA="oh=${OPTIONS_HASH}&cs=.big,.blue,.bold,.foo"
+BEACON_DATA="oh=${OPTIONS_HASH}&n=${NONCE}&cs=.big,.blue,.bold,.foo"
 
 # See the comments about 204 responses and --no-http-keep-alive above.
 OUT=$(wget -q  --save-headers -O - --no-http-keep-alive \


### PR DESCRIPTION
- statistics_logging_file_prefix is gine, replaced with log_dir
- propagate a units fix from apache_system_test
- test nonces for critical css beaconing

Previous trunk-tracking was at 3162.  Diff of apache_system_test.sh:
  https://code.google.com/p/modpagespeed/source/diff?path=/trunk/src/install/apache_system_test.sh&format=side&r=3193&old_path=/trunk/src/install/apache_system_test.sh&old=3162
