### PR TITLE
console: support /pagespeed_console

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ location ~ "^/ngx_pagespeed_static/" { }
 location ~ "^/ngx_pagespeed_beacon$" { }
 location /ngx_pagespeed_statistics { allow 127.0.0.1; deny all; }
 location /ngx_pagespeed_message { allow 127.0.0.1; deny all; }
+location /pagespeed_console { allow 127.0.0.1; deny all; }
 ```
 
 To confirm that the module is loaded, fetch a page and check that you see the

--- a/config
+++ b/config
@@ -170,6 +170,8 @@ if [ $ngx_found = yes ]; then
     $ps_src/ngx_thread_system.cc \
     $ps_src/ngx_url_async_fetcher.cc \
     $ps_src/pthread_shared_mem.cc \
+    $mod_pagespeed_dir/out/$buildtype/obj/gen/data2c_out/instaweb/net/instaweb/system/console_out.cc \
+    $mod_pagespeed_dir/out/$buildtype/obj/gen/data2c_out/instaweb/net/instaweb/system/console_css_out.cc \
     $mod_pagespeed_dir/net/instaweb/system/add_headers_fetcher.cc \
     $mod_pagespeed_dir/net/instaweb/system/loopback_route_fetcher.cc \
     $mod_pagespeed_dir/net/instaweb/system/serf_url_async_fetcher.cc"

--- a/scripts/prepare_psol.sh
+++ b/scripts/prepare_psol.sh
@@ -63,6 +63,8 @@ rsync -arvz "$MOD_PAGESPEED_SRC/" "psol/include/" --prune-empty-dirs \
   --include="apr_memcache2.c" \
   --include="loopback_route_fetcher.cc" \
   --include="add_headers_fetcher.cc" \
+  --include="console_css_out.cc" \
+  --include="console_out.cc" \
   --include="dense_hash_map" \
   --include="dense_hash_set" \
   --include="sparse_hash_map" \

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -39,6 +39,10 @@ http {
   # critical images to be inlined, so we just disable the option here.
   pagespeed CriticalImagesBeaconEnabled false;
 
+  pagespeed Statistics on;
+  pagespeed StatisticsLogging on;
+  pagespeed LogDir "@@TEST_TMP@@/logdir";
+
   server {
     # Sets up a logical home-page server on
     # max-cacheable-content-length.example.com.  This server is only used to
@@ -104,7 +108,7 @@ http {
       set $ua_dependent_ps_capability_list "";
       set $bypass_cache 1;
     }
-    
+
     location ~ /purge(/.*) {
       allow all;
       proxy_cache_purge htmlcache $ua_dependent_ps_capability_list$1$is_args$args;


### PR DESCRIPTION
sligocki is adding a feature to pagespeed where it will parse your statistics
for you and determine if there are any problems.  This CL wires up the
ConsoleHandler and also includes a few required files in the build process.

It doesn't work yet, because as of svn r3193 the console has a hardcoded json
request to '/mod_pagespeed_statistics' and in nginx we use '/ngx_...' .
I've tested this by changing all uses here to use the "mod_..." version and that
worked, but I've undone those changes.
