### PR TITLE
trunk-tracking: update to 1.6.29.2

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -306,6 +306,8 @@ typedef struct {
   // there as well.
   net_instaweb::NgxServerContext* server_context;
   net_instaweb::ProxyFetchFactory* proxy_fetch_factory;
+  // Only used while parsing config.  After we merge cfg_s and cfg_m you most
+  // likely want cfg_s->server_context->config() as options here will be NULL.
   net_instaweb::NgxRewriteOptions* options;
   net_instaweb::MessageHandler* handler;
 } ps_srv_conf_t;
@@ -2166,7 +2168,7 @@ ngx_int_t ps_console_handler(
   net_instaweb::MessageHandler* message_handler = factory->message_handler();
   GoogleString output;
   net_instaweb::StringWriter writer(&output);
-  ConsoleHandler(server_context, &writer, message_handler);
+  ConsoleHandler(server_context->config(), &writer, message_handler);
   ps_write_handler_response(output, r, factory->timer());
   return NGX_OK;
 }

--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -35,6 +35,12 @@ extern "C" {
 
 namespace net_instaweb {
 
+namespace {
+
+const char kNgxPagespeedStatisticsHandlerPath[] = "/ngx_pagespeed_statistics";
+
+}  // namespace
+
 RewriteOptions::Properties* NgxRewriteOptions::ngx_properties_ = NULL;
 
 NgxRewriteOptions::NgxRewriteOptions(ThreadSystem* thread_system)
@@ -46,6 +52,11 @@ void NgxRewriteOptions::Init() {
   DCHECK(ngx_properties_ != NULL)
       << "Call NgxRewriteOptions::Initialize() before construction";
   InitializeOptions(ngx_properties_);
+
+  // Nginx-specific default.
+  // TODO(sligocki): Get rid of this line and let both Apache and Nginx use
+  // /pagespeed_statistics as the handler.
+  statistics_handler_path_.set_default(kNgxPagespeedStatisticsHandlerPath);
 }
 
 void NgxRewriteOptions::AddProperties() {

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -515,7 +515,6 @@ http {
     location /mod_pagespeed_test/cachable_rewritten_html/ {
       # This location has the html files that will be configured to be stored
       # in the proxy_cache layer.
-      pagespeed DownstreamCacheLifetimeMs 100;
       pagespeed DownstreamCachePurgeMethod "GET";
       pagespeed DownstreamCachePurgeLocationPrefix "http://localhost:8051/purge";
       # We use a very small deadline here to force the rewriting to not complete


### PR DESCRIPTION
- ConsoleHandler now takes a RewriteOptions
- Console needs ports to override the statistics handler path.  Before the
  console just assumed statistics were available at /mod_pagespeed_statistics.
- The "nostore" test fails.  I've marked this as an expected failure and will
  fix it in a followup.
- downstream_cache_purges stat was renamed to downstream_cache_purge_attempts
- Proxying tests with gstatic no longer use 1.gif but are switched to
  pss-architecture.png.
- DownstreamCacheLifetimeMs option was removed.
