### PR TITLE
fetch-rate-limiting: add rate limiting for background fetches

### DIFF
--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -31,6 +31,8 @@
 #include "net/instaweb/apache/serf_url_async_fetcher.h"
 #include "net/instaweb/http/public/content_type.h"
 #include "net/instaweb/http/public/fake_url_async_fetcher.h"
+#include "net/instaweb/http/public/rate_controller.h"
+#include "net/instaweb/http/public/rate_controlling_url_async_fetcher.h"
 #include "net/instaweb/http/public/wget_url_fetcher.h"
 #include "net/instaweb/rewriter/public/rewrite_driver.h"
 #include "net/instaweb/rewriter/public/rewrite_driver_factory.h"
@@ -130,8 +132,10 @@ UrlAsyncFetcher* NgxRewriteDriverFactory::DefaultAsyncUrlFetcher() {
     fetcher_proxy = main_conf_->fetcher_proxy().c_str();
   }
 
+  UrlAsyncFetcher* fetcher = NULL;
+
   if (use_native_fetcher_) {
-    net_instaweb::NgxUrlAsyncFetcher* fetcher =
+    ngx_url_async_fetcher_ =
         new net_instaweb::NgxUrlAsyncFetcher(
             fetcher_proxy,
             log_,
@@ -140,10 +144,9 @@ UrlAsyncFetcher* NgxRewriteDriverFactory::DefaultAsyncUrlFetcher() {
             resolver_,
             thread_system(),
             message_handler());
-    ngx_url_async_fetcher_ = fetcher;
-    return fetcher;
+    fetcher = ngx_url_async_fetcher_;
   } else {
-    net_instaweb::SerfUrlAsyncFetcher* fetcher =
+    net_instaweb::SerfUrlAsyncFetcher* serf_fetcher =
         new net_instaweb::SerfUrlAsyncFetcher(
             fetcher_proxy,
             NULL,
@@ -153,9 +156,38 @@ UrlAsyncFetcher* NgxRewriteDriverFactory::DefaultAsyncUrlFetcher() {
             2500,
             message_handler());
     // Make sure we don't block the nginx event loop
-    fetcher->set_force_threaded(true);
-    return fetcher;
+    serf_fetcher->set_force_threaded(true);
+    fetcher = serf_fetcher;
   }
+
+  SystemRewriteOptions* system_options = dynamic_cast<SystemRewriteOptions*>(
+      default_options());
+  if (rate_limit_background_fetches_) {
+    // Unfortunately, we need stats for load-shedding.
+    if (system_options->statistics_enabled()) {
+      // TODO(oschaaf): mps bases this multiplier on the configured
+      // num_rewrite_threads_ which we don't have (yet).
+      int multiplier = 4;
+      fetcher = new RateControllingUrlAsyncFetcher(
+          fetcher,
+          500 * multiplier /* max queue size */,
+          multiplier /* requests/host */,
+          500 * multiplier /* queued per host */,
+          thread_system(),
+          statistics());
+      if (ngx_url_async_fetcher_ == NULL) {
+        defer_cleanup(new Deleter<SerfUrlAsyncFetcher>(
+            static_cast<net_instaweb::SerfUrlAsyncFetcher*>(fetcher)));
+      } else  {
+        defer_cleanup(new Deleter<net_instaweb::NgxUrlAsyncFetcher>(
+            ngx_url_async_fetcher_));
+      }
+    } else {
+      message_handler()->Message(
+          kError, "Can't enable fetch rate-limiting without statistics");
+    }
+  }
+  return fetcher;
 }
 
 MessageHandler* NgxRewriteDriverFactory::DefaultHtmlParseMessageHandler() {
@@ -379,7 +411,7 @@ AllocateAndInitSharedMemStatistics(
 void NgxRewriteDriverFactory::InitStats(Statistics* statistics) {
   // Init standard PSOL stats.
   RewriteDriverFactory::InitStats(statistics);
-
+  RateController::InitStats(statistics);
   // Init Ngx-specific stats.
   NgxServerContext::InitStats(statistics);
   SystemCaches::InitStats(statistics);

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -169,6 +169,9 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   void set_use_native_fetcher(bool x) {
     use_native_fetcher_ = x;
   }
+  void set_rate_limit_background_fetches(bool x) {
+    rate_limit_background_fetches_ = x;
+  }
 
   // We use a beacon handler to collect data for critical images,
   // css, etc., so filters should be configured accordingly.
@@ -211,6 +214,7 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   ngx_msec_t resolver_timeout_;
   ngx_resolver_t* resolver_;
   bool use_native_fetcher_;
+  bool rate_limit_background_fetches_;
 
   DISALLOW_COPY_AND_ASSIGN(NgxRewriteDriverFactory);
 };

--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -180,6 +180,17 @@ NgxRewriteOptions::ParseAndSetOptions(
         } else {
           result = RewriteOptions::kOptionValueInvalid;
         }
+      } else if (IsDirective(directive, "RateLimitBackgroundFetches")) {
+        // TODO(oschaaf): mod_pagespeed has a nicer way to do this.
+        if (IsDirective(arg, "on")) {
+          driver_factory->set_rate_limit_background_fetches(true);
+          result = RewriteOptions::kOptionOk;
+        } else if (IsDirective(arg, "off")) {
+          driver_factory->set_rate_limit_background_fetches(false);
+          result = RewriteOptions::kOptionOk;
+        } else {
+          result = RewriteOptions::kOptionValueInvalid;
+        }
       } else {
         result = ParseAndSetOptionFromName1(directive, args[1], &msg, handler);
       }


### PR DESCRIPTION
Limits the number of simultaneous background fetches performed.
Requires statistics to be turned on .

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/426
