### PR TITLE
keepalive-test: prevent false positives, filter a little more

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -92,7 +92,8 @@ function keepalive_test() {
     | grep -v "^\\* Connection.*left intact"\
     | grep -v "^} \\[data not shown"\
     | grep -v "^\\* upload completely sent off"\
-    | grep -v "^\\*   Trying.*\\.\\.\\. connected")
+    | grep -v "^\\* connected"\
+    | grep -v "^\\*   Trying.*\\.\\.\\.")
 
   # Nothing should remain after that.
   check [ -z "$OUT" ]


### PR DESCRIPTION
From the comments at https://github.com/pagespeed/ngx_pagespeed/pull/425,
on Chai's machine curl's output seems slightly different when it
reports it is trying to connect.

This makes the filtering a little more aggressively for these messages
