### PR TITLE
downstream-cache-test: don't hard code the port to 8051

### DIFF
--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -516,7 +516,7 @@ http {
       # This location has the html files that will be configured to be stored
       # in the proxy_cache layer.
       pagespeed DownstreamCachePurgeMethod "GET";
-      pagespeed DownstreamCachePurgeLocationPrefix "http://localhost:8051/purge";
+      pagespeed DownstreamCachePurgeLocationPrefix "http://localhost:@@SECONDARY_PORT@@/purge";
       # We use a very small deadline here to force the rewriting to not complete
       # in the very first attempt.
       pagespeed RewriteDeadlinePerFlushMs 1;


### PR DESCRIPTION
Small fix to make the tests pass for people who don't use the default ports when testing
