### PR TITLE
Updating trunk-tracking to be in sync with r3298.

### DIFF
--- a/config
+++ b/config
@@ -95,6 +95,7 @@ pagespeed_include="\
   $mod_pagespeed_dir/third_party/protobuf/src \
   $mod_pagespeed_dir/third_party/re2/src \
   $mod_pagespeed_dir/out/$buildtype/obj/gen \
+  $mod_pagespeed_dir/out/$buildtype/obj/gen/protoc_out/instaweb \
   $mod_pagespeed_dir/third_party/apr/src/include \
   $mod_pagespeed_dir/third_party/aprutil/src/include \
   $mod_pagespeed_dir/third_party/apr/gen/arch/$os_name/$arch_name/include \

--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -111,11 +111,11 @@ RewriteOptions::OptionSettingResult NgxRewriteOptions::ParseAndSetOptions0(
 
 
 RewriteOptions::OptionSettingResult
-    NgxRewriteOptions::ParseAndSetOptionFromEnum1(
-        OptionEnum directive, StringPiece arg,
+    NgxRewriteOptions::ParseAndSetOptionFromName1(
+        StringPiece name, StringPiece arg,
         GoogleString* msg, MessageHandler* handler) {
   // FileCachePath needs error checking.
-  if (directive == kFileCachePath) {
+  if (StringCaseEqual(name, kFileCachePath)) {
     if (!StringCaseStartsWith(arg, "/")) {
       *msg = "must start with a slash";
       return RewriteOptions::kOptionValueInvalid;
@@ -125,8 +125,8 @@ RewriteOptions::OptionSettingResult
   // TODO(jefftk): port these (no enums for them yet, even!)
   //  DangerPermitFetchFromUnknownHosts, FetchWithGzip, ForceCaching
 
-  return SystemRewriteOptions::ParseAndSetOptionFromEnum1(
-      directive, arg, msg, handler);
+  return SystemRewriteOptions::ParseAndSetOptionFromName1(
+      name, arg, msg, handler);
 }
 
 // Very similar to apache/mod_instaweb::ParseDirective.

--- a/src/ngx_rewrite_options.h
+++ b/src/ngx_rewrite_options.h
@@ -85,9 +85,8 @@ class NgxRewriteOptions : public SystemRewriteOptions {
   OptionSettingResult ParseAndSetOptions0(
       StringPiece directive, GoogleString* msg, MessageHandler* handler);
 
-  // These are called via RewriteOptions::ParseAndSetOptionFromName[123]
-  virtual OptionSettingResult ParseAndSetOptionFromEnum1(
-      OptionEnum name, StringPiece arg,
+  virtual OptionSettingResult ParseAndSetOptionFromName1(
+      StringPiece name, StringPiece arg,
       GoogleString* msg, MessageHandler* handler);
 
   // We may want to override 2- and 3-argument versions as well in the future,
@@ -109,8 +108,8 @@ class NgxRewriteOptions : public SystemRewriteOptions {
   static void add_ngx_option(typename OptionClass::ValueType default_value,
                              OptionClass RewriteOptionsSubclass::*offset,
                              const char* id,
-                             OptionEnum option_enum) {
-    AddProperty(default_value, offset, id, option_enum, ngx_properties_);
+                             StringPiece option_name) {
+    AddProperty(default_value, offset, id, option_name, ngx_properties_);
   }
 
   // Helper for ParseAndSetOptions.  Returns whether the two directives equal,


### PR DESCRIPTION
Fixes to allow ngx_pagespeed trunk-tracking branch to compile and work with r3298 mod_pagespeed revision:
- Config fix to include path for critical_keys.pb.h.
- Make changes needed due to RewriteOptions refactoring done in https://code.google.com/p/modpagespeed/source/detail?r=3226
