### PR TITLE
logging: respect error_log in nginx.conf server blocks

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -2759,6 +2759,11 @@ ngx_int_t ps_init_child_process(ngx_cycle_t* cycle) {
     if (cfg_s->server_context != NULL) {
       cfg_s->proxy_fetch_factory =
           new net_instaweb::ProxyFetchFactory(cfg_s->server_context);
+
+      ngx_http_core_loc_conf_t* clcf = static_cast<ngx_http_core_loc_conf_t*>(
+          cscfp[s]->ctx->loc_conf[ngx_http_core_module.ctx_index]);
+      cfg_m->driver_factory->SetServerContextMessageHandler(
+          cfg_s->server_context, clcf->error_log);
     }
   }
 

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -130,6 +130,8 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   // Creates and ::Initializes a shared memory statistics object.
   SharedMemStatistics* AllocateAndInitSharedMemStatistics(
       const StringPiece& name, const NgxRewriteOptions& options);
+  void SetServerContextMessageHandler(ServerContext* server_context,
+                                      ngx_log_t* log);
 
   NgxMessageHandler* ngx_message_handler() { return ngx_message_handler_; }
   void set_main_conf(NgxRewriteOptions* main_conf) {  main_conf_ = main_conf; }
@@ -211,6 +213,8 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   ngx_resolver_t* resolver_;
   bool use_native_fetcher_;
   bool rate_limit_background_fetches_;
+  typedef std::set<NgxMessageHandler*> NgxMessageHandlerSet;
+  NgxMessageHandlerSet server_context_message_handlers_;
 
   DISALLOW_COPY_AND_ASSIGN(NgxRewriteDriverFactory);
 };

--- a/src/ngx_server_context.cc
+++ b/src/ngx_server_context.cc
@@ -18,6 +18,7 @@
 
 #include "ngx_server_context.h"
 
+#include "ngx_message_handler.h"
 #include "ngx_request_context.h"
 #include "ngx_rewrite_driver_factory.h"
 #include "ngx_rewrite_options.h"

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -100,7 +100,8 @@ function keepalive_test() {
 
   # Filter the nginx log from our vhost from unimportant messages.
   OUT=$(cat "$TEST_TMP/$NGX_LOG_FILE"\
-    | grep -v "closed keepalive connection$")
+    | grep -v "closed keepalive connection$" \
+    | grep -v ".*Cache Flush.*")
 
   # Nothing should remain after that.
   check [ -z "$OUT" ]

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -472,35 +472,35 @@ http {
     server_name keepalive-html.example.com;
     pagespeed FileCachePath "@@FILE_CACHE@@";
     pagespeed RewriteLevel CoreFilters;
-    error_log "@@TEST_TMP@@/keepalive-html.example.com.error.log" info;
+    error_log "@@TEST_TMP@@/keepalive-html.example.com.error.log" warn;
   }
 
   server {
     listen @@SECONDARY_PORT@@;
     server_name keepalive-resource.example.com;
     pagespeed FileCachePath "@@FILE_CACHE@@";
-    error_log "@@TEST_TMP@@/keepalive-resource.example.com.error.log" info;
+    error_log "@@TEST_TMP@@/keepalive-resource.example.com.error.log" warn;
   }
 
   server {
     listen @@SECONDARY_PORT@@;
     server_name keepalive-beacon-get.example.com;
     pagespeed FileCachePath "@@FILE_CACHE@@";
-    error_log "@@TEST_TMP@@/keepalive-beacon-get.example.com.error.log" info;
+    error_log "@@TEST_TMP@@/keepalive-beacon-get.example.com.error.log" warn;
   }
 
   server {
     listen @@SECONDARY_PORT@@;
     server_name keepalive-beacon-post.example.com;
     pagespeed FileCachePath "@@FILE_CACHE@@";
-    error_log "@@TEST_TMP@@/keepalive-beacon-post.example.com.error.log" info;
+    error_log "@@TEST_TMP@@/keepalive-beacon-post.example.com.error.log" warn;
   }
 
   server {
     listen @@SECONDARY_PORT@@;
     server_name keepalive-static.example.com;
     pagespeed FileCachePath "@@FILE_CACHE@@";
-    error_log "@@TEST_TMP@@/keepalive-static.example.com.error.log" info;
+    error_log "@@TEST_TMP@@/keepalive-static.example.com.error.log" warn;
   }
 
   server {


### PR DESCRIPTION
This makes messages written via the NgxMessageHandler from the
NgxServerContext be written with the nginx error_log configuration
specified at the server{} level, if specified.

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/447
