### PR TITLE
IPRO: make it pass all tests

### DIFF
--- a/src/ngx_base_fetch.h
+++ b/src/ngx_base_fetch.h
@@ -84,6 +84,7 @@ class NgxBaseFetch : public AsyncFetch {
 
   // Called by nginx when it's done with us.
   void Release();
+  void set_handle_error(bool x) { handle_error_ = x; }
 
  private:
   virtual bool HandleWrite(const StringPiece& sp, MessageHandler* handler);
@@ -121,6 +122,7 @@ class NgxBaseFetch : public AsyncFetch {
   // decremented once when Done() is called and once when Release() is called.
   int references_;
   pthread_mutex_t mutex_;
+  bool handle_error_;
 
   DISALLOW_COPY_AND_ASSIGN(NgxBaseFetch);
 };

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -213,11 +213,8 @@ fi
 
 PSA_JS_LIBRARY_URL_PREFIX="ngx_pagespeed_static"
 
-PAGESPEED_EXPECTED_FAILURES="
-  ~In-place resource optimization~
-  ~dedup_inlined_images,inline_images~
-  ~Blocking rewrite enabled.~
-"
+# An expected failure can be indicated like: "~In-place resource optimization~"
+PAGESPEED_EXPECTED_FAILURES=""
 
 # The existing system test takes its arguments as positional parameters, and
 # wants different ones than we want, so we need to reset our positional args.
@@ -361,6 +358,7 @@ check_from "$OUT" grep "$EXPECTED_EXAMPLES_TEXT"
 
 # And also with bad request headers.
 OUT=$(wget -O - --header=PageSpeedFilters:bogus $EXAMPLE_ROOT)
+echo $OUT
 check_from "$OUT" grep "$EXPECTED_EXAMPLES_TEXT"
 
 # Test that loopback route fetcher works with vhosts not listening on
@@ -1250,13 +1248,8 @@ check $WGET_DUMP --header 'X-PSA-Blocking-Rewrite: psatest'\
 $WGET_DUMP $STATISTICS_URL > $NEWSTATS
 check_stat $OLDSTATS $NEWSTATS image_rewrites 1
 check_stat $OLDSTATS $NEWSTATS cache_hits 0
-# Something about IPRO means that in mod_pagespeed this comes in as 2.  Before
-# IPRO this said 1, and we're getting 1 in ngx_pagespeed, so I think this is
-# probably correct.
-check_stat $OLDSTATS $NEWSTATS cache_misses 1
-# In mod_pagespeed this is 2 cache inserts for image + 1 for HTML in IPRO flow.
-# We don't have IPRO, so this is just 2 cache inserts for the image.
-check_stat $OLDSTATS $NEWSTATS cache_inserts 2
+check_stat $OLDSTATS $NEWSTATS cache_misses 2
+check_stat $OLDSTATS $NEWSTATS cache_inserts 3
 # TODO(sligocki): There is no stat num_rewrites_executed. Fix.
 #check_stat $OLDSTATS $NEWSTATS num_rewrites_executed 1
 

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -650,6 +650,11 @@ http {
       pagespeed DisableFilters convert_jpeg_to_progressive;
     }
 
+    location /mod_pagespeed_test/ipro/test_image_dont_reuse.png {
+      expires 5m;
+    }
+
+
     pagespeed EnableFilters remove_comments;
 
     # Test LoadFromFile mapping by mapping one dir to another.


### PR DESCRIPTION
- Hand over the response headers we received to our
  InPlaceResourceRecorder
- Invent and pass in a Date response header set to the current date
  to the InPlaceResourceRecorder, if none is given.
- Set the appropriate expire configuration in the test configuration
  as required to enable ipro and pass the tests
- Port handle_error_ from ApacheProxyFetch
- Update the 'blocking rewrite enabled' tests expectations for IPRO
