### PR TITLE
header-handling: ModifyCachingheaders & Content-Encoding

### DIFF
--- a/src/ngx_base_fetch.cc
+++ b/src/ngx_base_fetch.cc
@@ -30,7 +30,8 @@ namespace net_instaweb {
 
 NgxBaseFetch::NgxBaseFetch(ngx_http_request_t* r, int pipe_fd,
                            NgxServerContext* server_context,
-                           const RequestContextPtr& request_ctx)
+                           const RequestContextPtr& request_ctx,
+                           bool modify_caching_headers)
     : AsyncFetch(request_ctx),
       request_(r),
       server_context_(server_context),
@@ -38,7 +39,8 @@ NgxBaseFetch::NgxBaseFetch(ngx_http_request_t* r, int pipe_fd,
       last_buf_sent_(false),
       pipe_fd_(pipe_fd),
       references_(2),
-      handle_error_(true) {
+      handle_error_(true),
+      modify_caching_headers_(modify_caching_headers) {
   if (pthread_mutex_init(&mutex_, NULL)) CHECK(0);
   PopulateRequestHeaders();
 }
@@ -120,7 +122,8 @@ ngx_int_t NgxBaseFetch::CollectHeaders(ngx_http_headers_out_t* headers_out) {
   //   headers_out->content_length_n = content_length();
   // }
 
-  return ngx_psol::copy_response_headers_to_ngx(request_, *pagespeed_headers);
+  return ngx_psol::copy_response_headers_to_ngx(request_, *pagespeed_headers,
+                                                modify_caching_headers_);
 }
 
 void NgxBaseFetch::RequestCollection() {

--- a/src/ngx_base_fetch.h
+++ b/src/ngx_base_fetch.h
@@ -57,7 +57,8 @@ class NgxBaseFetch : public AsyncFetch {
  public:
   NgxBaseFetch(ngx_http_request_t* r, int pipe_fd,
                NgxServerContext* server_context,
-               const RequestContextPtr& request_ctx);
+               const RequestContextPtr& request_ctx,
+               bool modify_caching_headers);
   virtual ~NgxBaseFetch();
 
   // Copies the request headers out of request_->headers_in->headers.
@@ -123,6 +124,7 @@ class NgxBaseFetch : public AsyncFetch {
   int references_;
   pthread_mutex_t mutex_;
   bool handle_error_;
+  bool modify_caching_headers_;
 
   DISALLOW_COPY_AND_ASSIGN(NgxBaseFetch);
 };

--- a/src/ngx_pagespeed.h
+++ b/src/ngx_pagespeed.h
@@ -89,7 +89,7 @@ typedef struct {
 
   bool write_pending;
   bool fetch_done;
-  bool modify_headers;
+  bool modify_caching_headers;
 
   // for html rewrite
   net_instaweb::ProxyFetch* proxy_fetch;
@@ -108,8 +108,9 @@ void copy_response_headers_from_ngx(const ngx_http_request_t *r,
        net_instaweb::ResponseHeaders *headers);
 
 ngx_int_t copy_response_headers_to_ngx(
-    ngx_http_request_t* r,
-    const net_instaweb::ResponseHeaders& pagespeed_headers);
+            ngx_http_request_t* r,
+            const net_instaweb::ResponseHeaders& pagespeed_headers,
+            bool modify_caching_headers);
 }  // namespace ngx_psol
 
 #endif  // NGX_PAGESPEED_H_


### PR DESCRIPTION
- Change header handling for ModifyCachingHeaders
- Don't copy over response headers which have their hash set to 0
