### PR TITLE
ipro: preconditions and limitations for ipro

### DIFF
--- a/src/in_place_resource_recorder.cc
+++ b/src/in_place_resource_recorder.cc
@@ -19,13 +19,14 @@
 // be removed.
 // TODO(jefftk): delete this when the next PSOL release after 1.6.29.3 is ready.
 
-#include "net/instaweb/apache/in_place_resource_recorder.h"
+#include "in_place_resource_recorder.h"
 
 #include "net/instaweb/http/public/http_cache.h"
 #include "net/instaweb/http/public/http_value.h"
 #include "net/instaweb/http/public/meta_data.h"
 #include "net/instaweb/http/public/request_headers.h"
 #include "net/instaweb/http/public/response_headers.h"
+#include "net/instaweb/util/public/message_handler.h"
 #include "net/instaweb/util/public/statistics.h"
 #include "net/instaweb/util/public/string_util.h"
 
@@ -39,76 +40,196 @@ const char kNumResources[] = "ipro_recorder_resources";
 const char kNumInsertedIntoCache[] = "ipro_recorder_inserted_into_cache";
 const char kNumNotCacheable[] = "ipro_recorder_not_cacheable";
 const char kNumFailed[] = "ipro_recorder_failed";
+const char kNumTooMany[] = "ipro_recorder_too_many";
+const char kNumTooLarge[] = "ipro_recorder_too_large";
 
-}
+int64 kIproMaxResponseBytesDefault = 1024 * 1024 * 10;
+int64 kIproMaxConcurrentRecordingsDefault = 10;
+int64 IproMaxResponseBytes = kIproMaxResponseBytesDefault;
+int64 IproMaxConcurrentRecordings = kIproMaxConcurrentRecordingsDefault;
 
-InPlaceResourceRecorder::InPlaceResourceRecorder(
+}  // namespace
+
+
+AtomicInt32 NgxInPlaceResourceRecorder::num_recordings_in_progress_(0);
+
+NgxInPlaceResourceRecorder::NgxInPlaceResourceRecorder(
     StringPiece url, RequestHeaders* request_headers, bool respect_vary,
     HTTPCache* cache, Statistics* stats, MessageHandler* handler)
     : url_(url.data(), url.size()), request_headers_(request_headers),
-      respect_vary_(respect_vary), success_(true), cache_(cache),
-      handler_(handler),
+      respect_vary_(respect_vary), cache_(cache), handler_(handler),
       num_resources_(stats->GetVariable(kNumResources)),
       num_inserted_into_cache_(stats->GetVariable(kNumInsertedIntoCache)),
       num_not_cacheable_(stats->GetVariable(kNumNotCacheable)),
-      num_failed_(stats->GetVariable(kNumFailed)) {
+      num_failed_(stats->GetVariable(kNumFailed)),
+      num_too_many_(stats->GetVariable(kNumTooMany)),
+      num_too_large_(stats->GetVariable(kNumTooLarge)),
+      headers_considered_(false),
+      response_headers_(NULL),
+      too_large_stat_incremented_(false),
+      success_(true),
+      needs_to_decrement_in_progress_(false) {
   num_resources_->Add(1);
 }
 
-InPlaceResourceRecorder::~InPlaceResourceRecorder() {
+NgxInPlaceResourceRecorder::~NgxInPlaceResourceRecorder() {
+  if (response_headers_ != NULL) {
+    delete response_headers_;
+    response_headers_ = NULL;
+  }
+  if (needs_to_decrement_in_progress_) {
+    num_recordings_in_progress_.BarrierIncrement(-1);
+    needs_to_decrement_in_progress_ = false;
+  }
 }
 
-void InPlaceResourceRecorder::InitStats(Statistics* statistics) {
+void NgxInPlaceResourceRecorder::InitStats(Statistics* statistics) {
   statistics->AddVariable(kNumResources);
   statistics->AddVariable(kNumInsertedIntoCache);
   statistics->AddVariable(kNumNotCacheable);
   statistics->AddVariable(kNumFailed);
+  statistics->AddVariable(kNumTooMany);
+  statistics->AddVariable(kNumTooLarge);
 }
 
+void NgxInPlaceResourceRecorder::InitLimits(
+    int ipro_max_response_bytes,
+    int ipro_max_concurrent_recordings) {
+  CHECK_GE(ipro_max_response_bytes, -1);
+  CHECK_GE(ipro_max_concurrent_recordings, -1);
+  IproMaxResponseBytes = ipro_max_response_bytes == -1 ?
+      kIproMaxResponseBytesDefault : ipro_max_response_bytes;
+  IproMaxConcurrentRecordings = ipro_max_concurrent_recordings == -1 ?
+      kIproMaxConcurrentRecordingsDefault : ipro_max_concurrent_recordings;
+}
 
-bool InPlaceResourceRecorder::Write(const StringPiece& contents,
+bool NgxInPlaceResourceRecorder::Write(const StringPiece& contents,
                                     MessageHandler* handler) {
-  return resource_value_.Write(contents, handler);
+  if (too_large_stat_incremented_) {
+    return false;
+  }
+  if (IproMaxResponseBytes == 0 ||
+      static_cast<int64>(resource_value_.size()) < IproMaxResponseBytes) {
+    return resource_value_.Write(contents, handler);
+  } else {
+    too_large_stat_incremented_ = true;
+    num_too_large_->Add(1);
+    cache_->RememberNotCacheable(url_, response_headers_->status_code() == 200,
+                                 handler_);
+    VLOG(1) << "IPRO: MaxResponseBytes exceeded while recording [" <<
+        url_ << "]";
+  }
+  return false;
 }
 
-bool InPlaceResourceRecorder::Flush(MessageHandler* handler) {
+bool NgxInPlaceResourceRecorder::Flush(MessageHandler* handler) {
   return true;
 }
 
-void InPlaceResourceRecorder::DoneAndSetHeaders(
+bool NgxInPlaceResourceRecorder::ConsiderResponseHeaders(
     ResponseHeaders* response_headers) {
-  if (success_) {
-    // TODO(sligocki): Currently this will cache HTML and other Content-Types
-    // that cannot be rewritten in-place. It seems like we should only cache
-    // resources that have a hope of being rewritten in-place, and store a
-    // failure in the IPRO meta-data lookup for all others.
+  CHECK(response_headers != NULL) << "Response headers cannot be NULL";
+  headers_considered_ = true;
 
-    bool is_cacheable =
-        response_headers->IsProxyCacheableGivenRequest(*request_headers_);
-    if (is_cacheable && respect_vary_) {
-      is_cacheable = response_headers->VaryCacheable(
-          request_headers_->Has(HttpAttributes::kCookie));
+  // First, check if IPRO applies considering the content type.
+  if (!IsIproContentType(response_headers)) {
+    cache_->RememberNotCacheable(url_, response_headers->status_code() == 200,
+                                 handler_);
+    return false;
+  }
+
+  bool is_cacheable =
+      response_headers->IsProxyCacheableGivenRequest(*request_headers_);
+  if (is_cacheable && respect_vary_) {
+    is_cacheable = response_headers->VaryCacheable(
+        request_headers_->Has(HttpAttributes::kCookie));
+  }
+  if (!is_cacheable) {
+    cache_->RememberNotCacheable(url_, response_headers->status_code() == 200,
+                                 handler_);
+    num_not_cacheable_->Add(1);
+    return false;
+  }
+
+  // Shortcut for bailing out early when the response will be too large
+  int64 content_length;
+  if (response_headers->FindContentLength(&content_length)) {
+    if (IproMaxResponseBytes > 0 && content_length > IproMaxResponseBytes) {
+      VLOG(1) << "IPRO: Content-Length header indicates that [" <<
+          url_ << "] is too large to record (" << content_length  << " bytes)";
+      cache_->RememberNotCacheable(url_, response_headers->status_code() == 200,
+                                   handler_);
+      num_too_large_->Add(1);
+      return false;
     }
+  }
 
-    // Put resource_value_ in cache.
-    if (is_cacheable) {
-      resource_value_.SetHeaders(response_headers);
+  // Copy the response headers, we might need them when Done()
+  if (IproMaxConcurrentRecordings == 0) {
+    response_headers_ = new ResponseHeaders();
+    response_headers_->CopyFrom(*response_headers);
+    return true;
+  }
+  if (num_recordings_in_progress_.BarrierIncrement(1) <=
+             IproMaxConcurrentRecordings) {
+    response_headers_ = new ResponseHeaders();
+    response_headers_->CopyFrom(*response_headers);
+    needs_to_decrement_in_progress_ = true;
+    return true;
+  } else {
+    VLOG(1) << "IPRO: too many recordings in progress, not recording";
+    num_recordings_in_progress_.BarrierIncrement(-1);
+    num_too_many_->Add(1);
+    return false;
+  }
+}
+
+void NgxInPlaceResourceRecorder::Done() {
+  num_recordings_in_progress_.BarrierIncrement(-1);
+  needs_to_decrement_in_progress_ = false;
+
+  if (success_) {
+    if (!too_large_stat_incremented_) {
+      // If a content length was specified, perform a sanity check on it
+      int64 content_length;
+      if (response_headers_->FindContentLength(&content_length)) {
+        if (static_cast<int64>(resource_value_.size()) != content_length) {
+          handler_->Message(kWarning,
+                            "IPRO: Mismatched content length for [%s]",
+                            url_.c_str());
+          num_failed_->Add(1);
+          delete this;
+          return;
+        }
+      }
+      resource_value_.SetHeaders(response_headers_);
       cache_->Put(url_, &resource_value_, handler_);
       // TODO(sligocki): Start IPRO rewrite.
       num_inserted_into_cache_->Add(1);
-    } else {
-      cache_->RememberNotCacheable(url_, response_headers->status_code() == 200,
-                                   handler_);
-      num_not_cacheable_->Add(1);
     }
   } else {
-    // TODO(sligocki): Should we RememberFetchFailed() if success_ == false?
-    // We don't expect this to happen much, it seems to only happen with Apache
-    // Bucket Brigade issues.
+    // TODO(sligocki): Should we RememberFetchFailed() if success == false?
+    // We don't expect this to happen much, it should only happen on aborted
+    // responses.
     num_failed_->Add(1);
   }
 
   delete this;
 }
+
+bool NgxInPlaceResourceRecorder::IsIproContentType(
+    ResponseHeaders* response_headers) {
+  bool is_ipro_content_type = false;
+  const net_instaweb::ContentType* content_type =
+      response_headers->DetermineContentType();
+
+  if (content_type != NULL) {
+    is_ipro_content_type = content_type->IsImage() || content_type->IsCss() ||
+        content_type->type() == net_instaweb::ContentType::kJavascript;
+  }
+
+  return is_ipro_content_type;
+}
+
 
 }  // namespace net_instaweb

--- a/src/in_place_resource_recorder.h
+++ b/src/in_place_resource_recorder.h
@@ -1,0 +1,104 @@
+// Copyright 2013 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: sligocki@google.com (Shawn Ligocki)
+
+#ifndef NET_INSTAWEB_SYSTEM_PUBLIC_IN_PLACE_RESOURCE_RECORDER_H_
+#define NET_INSTAWEB_SYSTEM_PUBLIC_IN_PLACE_RESOURCE_RECORDER_H_
+
+#include "net/instaweb/http/public/http_value.h"
+#include "net/instaweb/util/public/basictypes.h"
+#include "net/instaweb/util/public/scoped_ptr.h"
+#include "net/instaweb/util/public/string.h"
+#include "net/instaweb/util/public/string_util.h"
+#include "net/instaweb/util/public/writer.h"
+
+namespace net_instaweb {
+
+class HTTPCache;
+class MessageHandler;
+class RequestHeaders;
+class ResponseHeaders;
+class Statistics;
+class Variable;
+
+// Records a copy of a resource streamed through it and saves the result to
+// the cache if it's cacheable. Used in the In-Place Resource Optimization
+// (IPRO) flow to get resources into the cache.
+class NgxInPlaceResourceRecorder : public Writer {
+ public:
+  // Takes ownership of request_headers, but not cache nor handler.
+  // Like other callbacks, InPlaceResourceRecorder is self-owned and will
+  // delete itself when DoneAndSetHeaders(). is called.
+  NgxInPlaceResourceRecorder(StringPiece url, RequestHeaders* request_headers,
+                          bool respect_vary, HTTPCache* cache,
+                          Statistics* statistics, MessageHandler* handler);
+  virtual ~NgxInPlaceResourceRecorder();
+
+  static void InitStats(Statistics* statistics);
+  static void InitLimits(int ipro_max_response_bytes,
+                         int ipro_max_concurrent_recordings);
+
+  virtual bool Write(const StringPiece& contents, MessageHandler* handler);
+  virtual bool Flush(MessageHandler* handler);
+
+  // Call when finished and the final response headers are known.
+  // Because of Apache's quirky filter order, we cannot get both the
+  // uncompressed final contents and the complete headers at the same time.
+  //
+  // Deletes itself. Do not use object after calling Done().
+  void Done();
+  // Call this when the final response headers are known.
+  // Does not take ownership of response_headers.
+  // TODO(oschaaf): Might need an argument that takes the first few bytes of
+  // the response to be able to sniff the content type (later on)?
+  bool ConsiderResponseHeaders(ResponseHeaders* response_headers);
+  void Fail() { success_ = false; }
+
+  const GoogleString& url() const { return url_; }
+  MessageHandler* handler() { return handler_; }
+  bool headers_considered() { return headers_considered_; }
+
+ private:
+  bool IsIproContentType(ResponseHeaders* response_headers);
+
+  const GoogleString url_;
+  const scoped_ptr<RequestHeaders> request_headers_;
+  const bool respect_vary_;
+
+  HTTPValue resource_value_;
+
+  HTTPCache* cache_;
+  MessageHandler* handler_;
+
+  Variable* num_resources_;
+  Variable* num_inserted_into_cache_;
+  Variable* num_not_cacheable_;
+  Variable* num_failed_;
+  Variable* num_too_many_;
+  Variable* num_too_large_;
+
+  bool headers_considered_;
+  ResponseHeaders* response_headers_;
+  bool too_large_stat_incremented_;
+  static AtomicInt32 num_recordings_in_progress_;
+  bool success_;
+  bool needs_to_decrement_in_progress_;
+      
+  DISALLOW_COPY_AND_ASSIGN(NgxInPlaceResourceRecorder);
+};
+
+}  // namespace net_instaweb
+
+#endif  // NET_INSTAWEB_SYSTEM_PUBLIC_IN_PLACE_RESOURCE_RECORDER_H_

--- a/src/ngx_pagespeed.h
+++ b/src/ngx_pagespeed.h
@@ -45,7 +45,7 @@ class ProxyFetch;
 class RewriteDriver;
 class RequestHeaders;
 class ResponseHeaders;
-class InPlaceResourceRecorder;
+class NgxInPlaceResourceRecorder;
 }  // namespace net_instaweb
 
 namespace ngx_psol {
@@ -97,7 +97,7 @@ typedef struct {
 
   // for in place resource
   net_instaweb::RewriteDriver* driver;
-  net_instaweb::InPlaceResourceRecorder* recorder;
+  net_instaweb::NgxInPlaceResourceRecorder* recorder;
 } ps_request_ctx_t;
 
 

--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -20,6 +20,7 @@
 
 #include <cstdio>
 
+#include "in_place_resource_recorder.h"
 #include "log_message_handler.h"
 #include "ngx_message_handler.h"
 #include "ngx_rewrite_options.h"
@@ -36,7 +37,6 @@
 #include "net/instaweb/rewriter/public/rewrite_driver_factory.h"
 #include "net/instaweb/rewriter/public/server_context.h"
 #include "net/instaweb/rewriter/public/static_asset_manager.h"
-#include "net/instaweb/apache/in_place_resource_recorder.h"
 #include "net/instaweb/system/public/serf_url_async_fetcher.h"
 #include "net/instaweb/system/public/system_caches.h"
 #include "net/instaweb/system/public/system_rewrite_options.h"
@@ -93,7 +93,9 @@ NgxRewriteDriverFactory::NgxRewriteDriverFactory(
       ngx_url_async_fetcher_(NULL),
       log_(NULL),
       resolver_timeout_(NGX_CONF_UNSET_MSEC),
-      use_native_fetcher_(false) {
+      use_native_fetcher_(false),
+      ipro_max_concurrent_recordings_(-1 /*means default in recorder*/),
+      ipro_max_response_bytes_(-1 /*means default in recorder*/) {
   InitializeDefaultOptions();
   default_options()->set_beacon_url("/ngx_pagespeed_beacon");
   SystemRewriteOptions* system_options = dynamic_cast<SystemRewriteOptions*>(
@@ -431,7 +433,7 @@ void NgxRewriteDriverFactory::InitStats(Statistics* statistics) {
 
   // Init Ngx-specific stats.
   NgxServerContext::InitStats(statistics);
-  InPlaceResourceRecorder::InitStats(statistics);
+  NgxInPlaceResourceRecorder::InitStats(statistics);
 
   statistics->AddVariable(kShutdownCount);
 }

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -170,6 +170,18 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   void set_rate_limit_background_fetches(bool x) {
     rate_limit_background_fetches_ = x;
   }
+  int ipro_max_response_bytes() {
+    return ipro_max_response_bytes_;
+  }
+  void set_ipro_max_response_bytes(int x) {
+    ipro_max_response_bytes_ = x;
+  }
+  int ipro_max_concurrent_recordings() {
+    return ipro_max_concurrent_recordings_;
+  }
+  void set_ipro_max_concurrent_recordings(int x) {
+    ipro_max_concurrent_recordings_ = x;
+  }
 
   // We use a beacon handler to collect data for critical images,
   // css, etc., so filters should be configured accordingly.
@@ -215,6 +227,8 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   bool rate_limit_background_fetches_;
   typedef std::set<NgxMessageHandler*> NgxMessageHandlerSet;
   NgxMessageHandlerSet server_context_message_handlers_;
+  int ipro_max_concurrent_recordings_;
+  int ipro_max_response_bytes_;
 
   DISALLOW_COPY_AND_ASSIGN(NgxRewriteDriverFactory);
 };

--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -198,6 +198,25 @@ const char* NgxRewriteOptions::ParseAndSetOptions(
       result = ParseAndSetOptionHelper(
           arg, driver_factory,
           &NgxRewriteDriverFactory::set_force_caching);
+    } else if (IsDirective(directive, "IproMaxResponseBytes")) {
+      int ipro_max_response_bytes;
+      bool ok = StringToInt(arg.as_string(), &ipro_max_response_bytes);
+      if (ok && ipro_max_response_bytes >= 0) {
+        driver_factory->set_ipro_max_response_bytes(ipro_max_response_bytes);
+        result = RewriteOptions::kOptionOk;
+      } else {
+        result = RewriteOptions::kOptionValueInvalid;
+      }
+    } else if (IsDirective(directive, "IproMaxConcurrentRecordings")) {
+      int ipro_max_concurrent_recordings;
+      bool ok = StringToInt(arg.as_string(), &ipro_max_concurrent_recordings);
+      if (ok && ipro_max_concurrent_recordings >= 0) {
+        driver_factory->set_ipro_max_concurrent_recordings(
+            ipro_max_concurrent_recordings);
+        result = RewriteOptions::kOptionOk;
+      } else {
+        result = RewriteOptions::kOptionValueInvalid;
+      }
     } else {
       result = ParseAndSetOptionFromName1(directive, args[1], &msg, handler);
     }

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -30,6 +30,8 @@ http {
   root "@@SERVER_ROOT@@";
   pagespeed UsePerVHostStatistics on;
   pagespeed InPlaceResourceOptimization on;
+  pagespeed IproMaxResponseBytes 16384;
+  pagespeed IproMaxConcurrentRecordings 1;
   pagespeed CreateSharedMemoryMetadataCache "@@SHM_CACHE@@" 8192;
 
   # CriticalImagesBeaconEnabled is now on by default, but we disable in testing.
@@ -465,6 +467,15 @@ http {
     pagespeed BlockingRewriteKey psatest;
     pagespeed RewriteLevel PassThrough;
     pagespeed EnableFilters rewrite_images;
+  }
+
+  server {
+    listen @@SECONDARY_PORT@@;
+    server_name ipro-limitations.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    pagespeed RewriteLevel PassThrough;
+    pagespeed ModifyCachingHeaders off;
+    expires 1d;
   }
 
   server {


### PR DESCRIPTION
This prevents caching of html in the IPRO flow. More accurately,
it make sure that only contenttypes that are applicable will be
cached and treated as such. Also fixes leaking recorders for
aborted responses & incrementing the failure statistics for them.

Modification to (Ngx)InPlaceResourceRecorder:
- Adjust the interface to be able to bail out as soon as the
  decision can be made that IPRO cannot be applied. This prevents
  having to buffer a lot of responses
- Performs a sanity check on the content length received in the
  response headers (if any).
- Adds 2 statistics for tracking counts of ipro recordings dropped
  for being too large or when too many are in progress
