### PR TITLE
response-header-options: consider the response headers for options

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -1210,6 +1210,7 @@ ps_loc_conf_t* ps_get_loc_config(ngx_http_request_t* r) {
 net_instaweb::RewriteOptions* ps_determine_request_options(
     ngx_http_request_t* r,
     net_instaweb::RequestHeaders* request_headers,
+    net_instaweb::ResponseHeaders* response_headers,
     ps_srv_conf_t* cfg_s,
     net_instaweb::GoogleUrl* url) {
   // Stripping ModPagespeed query params before the property cache lookup to
@@ -1217,7 +1218,8 @@ net_instaweb::RewriteOptions* ps_determine_request_options(
   //
   // Sets option from request headers and url.
   net_instaweb::ServerContext::OptionsBoolPair query_options_success =
-      cfg_s->server_context->GetQueryOptions(url, request_headers, NULL);
+      cfg_s->server_context->GetQueryOptions(url, request_headers,
+                                             response_headers);
   bool get_query_options_success = query_options_success.second;
   if (!get_query_options_success) {
     // Failed to parse query params or request headers.  Treat this as if there
@@ -1290,6 +1292,7 @@ bool ps_set_experiment_state_and_cookie(ngx_http_request_t* r,
 // set options to NULL so we can use server_context->global_options().
 bool ps_determine_options(ngx_http_request_t* r,
                           net_instaweb::RequestHeaders* request_headers,
+                          net_instaweb::ResponseHeaders* response_headers,
                           net_instaweb::RewriteOptions** options,
                           net_instaweb::GoogleUrl* url) {
   ps_srv_conf_t* cfg_s = ps_get_srv_config(r);
@@ -1306,7 +1309,8 @@ bool ps_determine_options(ngx_http_request_t* r,
   // Request-specific options, nearly always null.  If set they need to be
   // rebased on the directory options or the global options.
   net_instaweb::RewriteOptions* request_options =
-      ps_determine_request_options(r, request_headers, cfg_s, url);
+      ps_determine_request_options(r, request_headers, response_headers,
+                                   cfg_s, url);
 
   // Because the caller takes memory ownership of any options we return, the
   // only situation in which we can avoid allocating a new RewriteOptions is if
@@ -1717,12 +1721,16 @@ ngx_int_t ps_resource_handler(ngx_http_request_t *r, bool html_rewrite) {
 
   scoped_ptr<net_instaweb::RequestHeaders> request_headers(
                                 new net_instaweb::RequestHeaders);
+  scoped_ptr<net_instaweb::ResponseHeaders> response_headers(
+                                new net_instaweb::ResponseHeaders);
 
   copy_request_headers_from_ngx(r, request_headers.get());
+  copy_response_headers_from_ngx(r, response_headers.get());
 
   net_instaweb::RewriteOptions *options = NULL;
 
-  if (!ps_determine_options(r, request_headers.get(), &options, &url)) {
+  if (!ps_determine_options(r, request_headers.get(), response_headers.get(),
+                            &options, &url)) {
     return NGX_ERROR;
   }
 

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1659,4 +1659,12 @@ check_from "$JS_HEADERS" fgrep -qi 'Vary: Accept-Encoding'
 check_from "$JS_HEADERS" egrep -qi 'Etag: W/"0"'
 check_from "$JS_HEADERS" fgrep -qi 'Last-Modified:'
 
+
+start_test PageSpeedFilters response headers is interpreted
+URL=$SECONDARY_HOSTNAME/mod_pagespeed_example/
+OUT=$($WGET_DUMP --header=Host:response-header-filters.example.com $URL)
+check_from "$OUT" egrep -qi 'addInstrumentationInit'
+OUT=$($WGET_DUMP --header=Host:response-header-disable.example.com $URL)
+check_not_from "$OUT" egrep -qi 'addInstrumentationInit'
+
 check_failures_and_exit

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -504,6 +504,24 @@ http {
   }
 
   server {
+    listen @@SECONDARY_PORT@@;
+    server_name response-header-filters.example.com;
+    pagespeed FileCachePath "@@SECONDARY_CACHE@@";
+    pagespeed RewriteLevel PassThrough;
+    pagespeed on;
+    add_header PageSpeedFilters add_instrumentation;
+  }
+
+  server {
+    listen @@SECONDARY_PORT@@;
+    server_name response-header-disable.example.com;
+    pagespeed FileCachePath "@@SECONDARY_CACHE@@";
+    pagespeed EnableFilters add_instrumentation;
+    pagespeed on;
+    add_header PageSpeed off;
+  }
+
+  server {
     listen       @@PRIMARY_PORT@@;
     server_name  localhost;
     pagespeed FileCachePath "@@FILE_CACHE@@";


### PR DESCRIPTION
Take the response headers into account when determining the options
for the request.

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/356
