### PR TITLE
headers: simplify header setting

### DIFF
--- a/src/ngx_base_fetch.cc
+++ b/src/ngx_base_fetch.cc
@@ -42,7 +42,6 @@ NgxBaseFetch::NgxBaseFetch(ngx_http_request_t* r, int pipe_fd,
       handle_error_(true),
       modify_caching_headers_(modify_caching_headers) {
   if (pthread_mutex_init(&mutex_, NULL)) CHECK(0);
-  PopulateRequestHeaders();
 }
 
 NgxBaseFetch::~NgxBaseFetch() {
@@ -56,15 +55,6 @@ void NgxBaseFetch::Lock() {
 void NgxBaseFetch::Unlock() {
   pthread_mutex_unlock(&mutex_);
 }
-
-void NgxBaseFetch::PopulateRequestHeaders() {
-  ngx_psol::copy_request_headers_from_ngx(request_, request_headers());
-}
-
-void NgxBaseFetch::PopulateResponseHeaders() {
-  ngx_psol::copy_response_headers_from_ngx(request_, response_headers());
-}
-
 
 bool NgxBaseFetch::HandleWrite(const StringPiece& sp,
                                MessageHandler* handler) {

--- a/src/ngx_base_fetch.h
+++ b/src/ngx_base_fetch.h
@@ -61,12 +61,6 @@ class NgxBaseFetch : public AsyncFetch {
                bool modify_caching_headers);
   virtual ~NgxBaseFetch();
 
-  // Copies the request headers out of request_->headers_in->headers.
-  void PopulateRequestHeaders();
-
-  // Copies the response headers out of request_->headers_out->headers.
-  void PopulateResponseHeaders();
-
   // Puts a chain in link_ptr if we have any output data buffered.  Returns
   // NGX_OK on success, NGX_ERROR on errors.  If there's no data to send, sends
   // data only if Done() has been called.  Indicates the end of output by

--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -218,9 +218,8 @@ void copy_headers_from_table(const ngx_list_t &from, Headers* to) {
 }
 }  // namespace
 
-// modify from NgxBaseFetch::PopulateResponseHeaders()
 void copy_response_headers_from_ngx(const ngx_http_request_t* r,
-        net_instaweb::ResponseHeaders* headers) {
+                                    net_instaweb::ResponseHeaders* headers) {
   headers->set_major_version(r->http_version / 1000);
   headers->set_minor_version(r->http_version % 1000);
   copy_headers_from_table(r->headers_out.headers, headers);
@@ -230,13 +229,12 @@ void copy_response_headers_from_ngx(const ngx_http_request_t* r,
   // Manually copy over the content type because it's not included in
   // request_->headers_out.headers.
   headers->Add(net_instaweb::HttpAttributes::kContentType,
-              ngx_psol::str_to_string_piece(r->headers_out.content_type));
+               ngx_psol::str_to_string_piece(r->headers_out.content_type));
 
   // TODO(oschaaf): ComputeCaching should be called in setupforhtml()?
   headers->ComputeCaching();
 }
 
-// modify from NgxBaseFetch::PopulateRequestHeaders()
 void copy_request_headers_from_ngx(const ngx_http_request_t* r,
                                    net_instaweb::RequestHeaders* headers) {
   // TODO(chaizhenhua): only allow RewriteDriver::kPassThroughRequestAttributes?
@@ -2167,9 +2165,8 @@ ngx_int_t ps_html_rewrite_header_filter(ngx_http_request_t* r) {
 
   ps_strip_html_headers(r);
 
-
   // TODO(jefftk): is this thread safe?
-  ctx->base_fetch->PopulateResponseHeaders();
+  copy_response_headers_from_ngx(r, ctx->base_fetch->response_headers());
 
   ps_set_buffered(r, true);
   r->filter_need_in_memory = 1;


### PR DESCRIPTION
- Remove PopulateRequestHeaders() and PopulateResponseHeaders().
- Set stop copying request headers to the base fetch twice.
  - This fixes a dcheck failure in the debug build.
