### PR TITLE
Removing redundant X-Cache header handling.

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -2123,20 +2123,6 @@ ngx_int_t ps_html_rewrite_header_filter(ngx_http_request_t* r) {
     return ngx_http_next_header_filter(r);
   }
 
-  ngx_table_elt_t* header;
-  net_instaweb::NgxListIterator it(&(r->headers_out.headers.part));
-  while ((header = it.Next()) != NULL) {
-    // If there is a proxy_cache configured in front of this ngx server,
-    // we expect it to add a X-Cache header with the value of the cache
-    // status (one of HIT, MISS, EXPIRED).
-    if (STR_CASE_EQ_LITERAL(header->key, "X-Cache") &&
-        STR_CASE_EQ_LITERAL(header->value, "HIT")) {
-      // Bypass content handling by pagespeed modules if this is a cache hit.
-      ctx->html_rewrite = false;
-      return ngx_http_next_header_filter(r);
-    }
-  }
-
   ngx_int_t rc = ps_resource_handler(r, true);
   if (rc != NGX_OK) {
     ctx->html_rewrite = false;


### PR DESCRIPTION
X-Cache handling is not needed because the pagespeed server never gets to see
a request with X-Cache header added by its downstream cache. X-Cache headers
are only to be added in responses served out of the downstream cache for debugging
purposes only. This piece of deleted code was also conflicting with X-Cache
headers present on upstream caches (wrt pagespeed) and hence not optimizing responses
that happened to carry this header.

(More details are present in https://github.com/pagespeed/ngx_pagespeed/issues/488)
