### PR TITLE
trunk-tracking: update to r3448 from r3403 

### DIFF
--- a/config
+++ b/config
@@ -169,8 +169,6 @@ if [ $ngx_found = yes ]; then
     $ps_src/ngx_server_context.cc \
     $ps_src/ngx_thread_system.cc \
     $ps_src/ngx_url_async_fetcher.cc \
-    $mod_pagespeed_dir/out/$buildtype/obj/gen/data2c_out/instaweb/net/instaweb/system/console_out.cc \
-    $mod_pagespeed_dir/out/$buildtype/obj/gen/data2c_out/instaweb/net/instaweb/system/console_css_out.cc \
     $mod_pagespeed_dir/net/instaweb/system/add_headers_fetcher.cc \
     $mod_pagespeed_dir/net/instaweb/system/loopback_route_fetcher.cc \
     $mod_pagespeed_dir/net/instaweb/system/serf_url_async_fetcher.cc"

--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -171,8 +171,9 @@ bool NgxRewriteDriverFactory::CheckResolver() {
   return true;
 }
 
-NgxServerContext* NgxRewriteDriverFactory::MakeNgxServerContext() {
-  NgxServerContext* server_context = new NgxServerContext(this);
+NgxServerContext* NgxRewriteDriverFactory::MakeNgxServerContext(
+    StringPiece hostname, int port) {
+  NgxServerContext* server_context = new NgxServerContext(this, hostname, port);
   uninitialized_server_contexts_.insert(server_context);
   return server_context;
 }

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -80,7 +80,7 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   // NgxRewriteDriverFactory, including nginx-specific and
   // platform-independent statistics.
   static void InitStats(Statistics* statistics);
-  NgxServerContext* MakeNgxServerContext();
+  NgxServerContext* MakeNgxServerContext(StringPiece hostname, int port);
   ServerContext* NewServerContext();
 
   // Starts pagespeed threads if they've not been started already.  Must be

--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -43,6 +43,12 @@ const char kNgxPagespeedStatisticsHandlerPath[] = "/ngx_pagespeed_statistics";
 
 RewriteOptions::Properties* NgxRewriteOptions::ngx_properties_ = NULL;
 
+NgxRewriteOptions::NgxRewriteOptions(const StringPiece& description,
+                                     ThreadSystem* thread_system)
+    : SystemRewriteOptions(description, thread_system) {
+  Init();
+}
+
 NgxRewriteOptions::NgxRewriteOptions(ThreadSystem* thread_system)
     : SystemRewriteOptions(thread_system) {
   Init();
@@ -189,14 +195,6 @@ const char* NgxRewriteOptions::ParseAndSetOptions(
       result = ParseAndSetOptionHelper<SystemRewriteDriverFactory>(
           arg, driver_factory,
           &SystemRewriteDriverFactory::set_force_caching);
-    } else if (IsDirective(directive, "DangerFetchFromUnknownHosts")) {
-      result = ParseAndSetOptionHelper<SystemRewriteDriverFactory>(
-          arg, driver_factory,
-          &SystemRewriteDriverFactory::set_disable_loopback_routing);
-    } else if (IsDirective(directive, "FetchWithGzip")) {
-      result = ParseAndSetOptionHelper<SystemRewriteDriverFactory>(
-          arg, driver_factory,
-          &SystemRewriteDriverFactory::set_fetch_with_gzip);
     } else if (IsDirective(directive, "ListOutstandingUrlsOnError")) {
       result = ParseAndSetOptionHelper<SystemRewriteDriverFactory>(
           arg, driver_factory,
@@ -256,7 +254,8 @@ const char* NgxRewriteOptions::ParseAndSetOptions(
 }
 
 NgxRewriteOptions* NgxRewriteOptions::Clone() const {
-  NgxRewriteOptions* options = new NgxRewriteOptions(thread_system());
+  NgxRewriteOptions* options = new NgxRewriteOptions(
+      StrCat("cloned from ", description()), thread_system());
   options->Merge(*this);
   return options;
 }

--- a/src/ngx_rewrite_options.h
+++ b/src/ngx_rewrite_options.h
@@ -40,6 +40,7 @@ class NgxRewriteOptions : public SystemRewriteOptions {
   static void Initialize();
   static void Terminate();
 
+  NgxRewriteOptions(const StringPiece& description, ThreadSystem* thread_system);
   explicit NgxRewriteOptions(ThreadSystem* thread_system);
   virtual ~NgxRewriteOptions() { }
 

--- a/src/ngx_server_context.cc
+++ b/src/ngx_server_context.cc
@@ -26,117 +26,22 @@ extern "C" {
 #include "ngx_message_handler.h"
 #include "ngx_rewrite_driver_factory.h"
 #include "ngx_rewrite_options.h"
-#include "net/instaweb/http/public/url_async_fetcher_stats.h"
 #include "net/instaweb/rewriter/public/rewrite_driver.h"
-#include "net/instaweb/rewriter/public/rewrite_stats.h"
 #include "net/instaweb/system/public/add_headers_fetcher.h"
 #include "net/instaweb/system/public/loopback_route_fetcher.h"
-#include "net/instaweb/system/public/system_caches.h"
 #include "net/instaweb/system/public/system_request_context.h"
-#include "net/instaweb/util/public/shared_mem_statistics.h"
-#include "net/instaweb/util/public/split_statistics.h"
-#include "net/instaweb/util/public/statistics.h"
 
 namespace net_instaweb {
 
-namespace {
-
-const char kLocalFetcherStatsPrefix[] = "http";
-
-}  // namespace
-
-const char kCacheFlushCount[] = "cache_flush_count";
-const char kCacheFlushTimestampMs[] = "cache_flush_timestamp_ms";
-
-// Statistics histogram names.
-const char kHtmlRewriteTimeUsHistogram[] = "Html Time us Histogram";
-
-
-NgxServerContext::NgxServerContext(NgxRewriteDriverFactory* factory)
-    : SystemServerContext(factory),
-      ngx_factory_(factory),
-      initialized_(false) {
+NgxServerContext::NgxServerContext(
+    NgxRewriteDriverFactory* factory, StringPiece hostname, int port)
+    : SystemServerContext(factory, hostname, port) {
 }
 
-NgxServerContext::~NgxServerContext() {
-}
+NgxServerContext::~NgxServerContext() { }
 
 NgxRewriteOptions* NgxServerContext::config() {
   return NgxRewriteOptions::DynamicCast(global_options());
-}
-
-void NgxServerContext::ChildInit() {
-  // TODO(jefftk): move this function into SystemServerContext
-
-  DCHECK(!initialized_);
-  if (!initialized_) {
-    initialized_ = true;
-    set_lock_manager(ngx_factory_->caches()->GetLockManager(config()));
-    UrlAsyncFetcher* fetcher = ngx_factory_->GetFetcher(config());
-    set_default_system_fetcher(fetcher);
-
-    if (split_statistics_.get() != NULL) {
-      // Readjust the SHM stuff for the new process
-      local_statistics_->Init(false, message_handler());
-
-      // Create local stats for the ServerContext, and fill in its
-      // statistics() and rewrite_stats() using them; if we didn't do this here
-      // they would get set to the factory's by the InitServerContext call
-      // below.
-      set_statistics(split_statistics_.get());
-      local_rewrite_stats_.reset(new RewriteStats(
-          split_statistics_.get(), ngx_factory_->thread_system(),
-          ngx_factory_->timer()));
-      set_rewrite_stats(local_rewrite_stats_.get());
-
-      // In case of gzip fetching, we will have the UrlAsyncFetcherStats take
-      // care of it rather than the original fetcher, so we get correct
-      // numbers for bytes fetched.
-      if (ngx_factory_->fetch_with_gzip()) {
-        fetcher->set_fetch_with_gzip(false);
-      }
-      stats_fetcher_.reset(new UrlAsyncFetcherStats(
-          kLocalFetcherStatsPrefix, fetcher,
-          ngx_factory_->timer(), split_statistics_.get()));
-      if (ngx_factory_->fetch_with_gzip()) {
-        stats_fetcher_->set_fetch_with_gzip(true);
-      }
-      set_default_system_fetcher(stats_fetcher_.get());
-    }
-
-    // To allow Flush to come in while multiple threads might be
-    // referencing the signature, we must be able to mutate the
-    // timestamp and signature atomically.  RewriteOptions supports
-    // an optional read/writer lock for this purpose.
-    global_options()->set_cache_invalidation_timestamp_mutex(
-        thread_system()->NewRWLock());
-    ngx_factory_->InitServerContext(this);
-  }
-}
-
-void NgxServerContext::CreateLocalStatistics(
-    Statistics* global_statistics) {
-  local_statistics_ =
-      ngx_factory_->AllocateAndInitSharedMemStatistics(
-          true /* local */, hostname_identifier(), *config());
-  split_statistics_.reset(new SplitStatistics(
-      ngx_factory_->thread_system(), local_statistics_, global_statistics));
-  // local_statistics_ was ::InitStat'd by AllocateAndInitSharedMemStatistics,
-  // but we need to take care of split_statistics_.
-  NgxRewriteDriverFactory::InitStats(split_statistics_.get());
-}
-
-void NgxServerContext::InitStats(Statistics* statistics) {
-  // TODO(oschaaf): we need to port the cache flush mechanism
-  statistics->AddVariable(kCacheFlushCount);
-  statistics->AddVariable(kCacheFlushTimestampMs);
-  Histogram* html_rewrite_time_us_histogram =
-      statistics->AddHistogram(kHtmlRewriteTimeUsHistogram);
-  // We set the boundary at 2 seconds which is about 2 orders of magnitude
-  // worse than anything we have reasonably seen, to make sure we don't
-  // cut off actual samples.
-  html_rewrite_time_us_histogram->SetMaxValue(2 * Timer::kSecondUs);
-  UrlAsyncFetcherStats::InitStats(kLocalFetcherStatsPrefix, statistics);
 }
 
 SystemRequestContext* NgxServerContext::NewRequestContext(

--- a/src/ngx_server_context.h
+++ b/src/ngx_server_context.h
@@ -31,15 +31,12 @@ namespace net_instaweb {
 
 class NgxRewriteDriverFactory;
 class NgxRewriteOptions;
-class RewriteStats;
-class SharedMemStatistics;
-class Statistics;
 class SystemRequestContext;
-class UrlAsyncFetcherStats;
 
 class NgxServerContext : public SystemServerContext {
  public:
-  explicit NgxServerContext(NgxRewriteDriverFactory* factory);
+  NgxServerContext(
+      NgxRewriteDriverFactory* factory, StringPiece hostname, int port);
   virtual ~NgxServerContext();
 
   // We expect to use ProxyFetch with HTML.
@@ -49,34 +46,12 @@ class NgxServerContext : public SystemServerContext {
   // nginx-specific behavior, call global_options() instead which doesn't
   // downcast.
   NgxRewriteOptions* config();
-  // Should be called after the child process is forked.
-  void ChildInit();
-  // Initialize this ServerContext to have its own statistics domain.
-  // Must be called after global_statistics has been created and had
-  // ::Initialize called on it.
-  void CreateLocalStatistics(Statistics* global_statistics);
-  static void InitStats(Statistics* statistics);
-  bool initialized() const { return initialized_; }
-  GoogleString hostname_identifier() { return hostname_identifier_; }
-  void set_hostname_identifier(GoogleString x) { hostname_identifier_ = x; }
+
   NgxRewriteDriverFactory* ngx_rewrite_driver_factory() { return ngx_factory_; }
   SystemRequestContext* NewRequestContext(ngx_http_request_t* r);
 
  private:
   NgxRewriteDriverFactory* ngx_factory_;
-  // hostname_identifier_ is used to distinguish the name of shared memory
-  // segments associated with this ServerContext
-  GoogleString hostname_identifier_;
-  bool initialized_;
-
-  // Non-NULL if we have per-vhost stats.
-  scoped_ptr<Statistics> split_statistics_;
-
-  // May be NULL. Owned by *split_statistics_.
-  SharedMemStatistics* local_statistics_;
-  // These are non-NULL if we have per-vhost stats.
-  scoped_ptr<RewriteStats> local_rewrite_stats_;
-  scoped_ptr<UrlAsyncFetcherStats> stats_fetcher_;
 
   DISALLOW_COPY_AND_ASSIGN(NgxServerContext);
 };

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1575,6 +1575,41 @@ check [ `grep -c '<style>[.]big{[^}]*}</style>' $FETCH_UNTIL_OUTFILE` = 1 ]
 check [ `grep -c '<style>[.]blue{[^}]*}[.]bold{[^}]*}</style>' \
   $FETCH_UNTIL_OUTFILE` = 1 ]
 
+# This test checks that the ClientDomainRewrite directive can turn on.
+start_test ClientDomainRewrite on directive
+HOST_NAME="http://client-domain-rewrite.example.com"
+RESPONSE_OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP \
+  $HOST_NAME/mod_pagespeed_test/rewrite_domains.html)
+MATCHES=$(echo "$RESPONSE_OUT" | grep -c pagespeed\.clientDomainRewriterInit)
+check [ $MATCHES -eq 1 ]
+
+# Verify rendered image dimensions test.
+WGET_ARGS=""
+start_test resize_rendered_image_dimensions with critical images beacon
+HOST_NAME="http://renderedimagebeacon.example.com"
+URL="$HOST_NAME/mod_pagespeed_test/image_rewriting/image_resize_using_rendered_dimensions.html"
+http_proxy=$SECONDARY_HOSTNAME\
+    fetch_until -save -recursive $URL 'fgrep -c "pagespeed_url_hash"' 1 \
+'--header=X-PSA-Blocking-Rewrite:psatest'
+check [ $(grep -c "^pagespeed\.criticalImagesBeaconInit" \
+  $OUTDIR/image_resize_using_rendered_dimensions.html) = 1 ];
+OPTIONS_HASH=$(grep "^pagespeed\.criticalImagesBeaconInit" \
+  $OUTDIR/image_resize_using_rendered_dimensions.html | \
+  awk -F\' '{print $(NF-3)}')
+
+# Send a beacon response using POST indicating that OptPuzzle.jpg is
+# critical and has rendered dimensions.
+BEACON_URL="$HOST_NAME/ngx_pagespeed_beacon"
+BEACON_URL+="?url=http%3A%2F%2Frenderedimagebeacon.example.com%2Fmod_pagespeed_test%2F"
+BEACON_URL+="image_rewriting%2Fimage_resize_using_rendered_dimensions.html"
+BEACON_DATA="oh=$OPTIONS_HASH&ci=1344500982&rd=%7B%221344500982%22%3A%7B%22renderedWidth%22%3A150%2C%22renderedHeight%22%3A100%2C%22originalWidth%22%3A256%2C%22originalHeight%22%3A192%7D%7D"
+OUT=$(env http_proxy=$SECONDARY_HOSTNAME \
+  $WGET_DUMP --post-data "$BEACON_DATA" "$BEACON_URL")
+check_from "$OUT" egrep -q "HTTP/1[.]. 204"
+http_proxy=$SECONDARY_HOSTNAME \
+  fetch_until -save -recursive $URL \
+  'fgrep -c 150x100xOptPuzzle.jpg.pagespeed.ic.' 1
+
 # Verify that we can send a critical image beacon and that lazyload_images
 # does not try to lazyload the critical images.
 WGET_ARGS=""
@@ -1591,7 +1626,7 @@ check [ $(grep -c "^pagespeed\.criticalImagesBeaconInit" \
 # We need the options hash to send a critical image beacon, so extract it from
 # injected beacon JS.
 OPTIONS_HASH=$(grep "^pagespeed\.criticalImagesBeaconInit" \
-  $OUTDIR/rewrite_images.html | awk -F\' '{print $(NF-1)}')
+  $OUTDIR/rewrite_images.html | awk -F\' '{print $(NF-3)}')
 # Send a beacon response using POST indicating that Puzzle.jpg is a critical
 # image.
 BEACON_URL="$HOST_NAME/ngx_pagespeed_beacon"

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -200,6 +200,16 @@ http {
   }
 
   server {
+    listen @@SECONDARY_PORT@@;
+    server_name renderedimagebeacon.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+
+    pagespeed RewriteLevel PassThrough;
+    pagespeed EnableFilters resize_rendered_image_dimensions;
+    pagespeed CriticalImagesBeaconEnabled true;
+  }
+
+  server {
     # Sets up a virtual host where we can specify forbidden filters without
     # affecting any other hosts.
     listen @@SECONDARY_PORT@@;
@@ -215,6 +225,21 @@ http {
     pagespeed ForbidFilters rewrite_css,resize_images;
     # ... and disable but not forbid this one (to ensure we retain its URL).
     pagespeed DisableFilters inline_css;
+  }
+
+  server {
+    listen @@SECONDARY_PORT@@;
+    server_name client-domain-rewrite.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+
+    # Don't actually try to rewrite any resources; the ones in
+    # rewrite_domains.html don't actually exist.
+    pagespeed RewriteLevel PassThrough;
+
+    pagespeed MapRewriteDomain http://client-domain-rewrite.example.com
+              http://src.example.com;
+    pagespeed ClientDomainRewrite true;
+    pagespeed EnableFilters rewrite_domains;
   }
 
   server {


### PR DESCRIPTION
As of r3447, `ServerContext::ChildInit` is now in `system/`, which means we can delete a lot of code.

`DangerFetchFromUnknownHosts` and `FetchWithGzip` are now handled by `RewriteOptions`.

`ServerContext` now needs a hostname and port, but we don't have one so we hackishly provide a different unique id.
