### PR TITLE
code cleanup

### DIFF
--- a/src/ngx_base_fetch.cc
+++ b/src/ngx_base_fetch.cc
@@ -75,7 +75,7 @@ ngx_int_t NgxBaseFetch::CopyBufferToNginx(ngx_chain_t** link_ptr) {
     return NGX_AGAIN;
   }
 
-  int rc = ngx_psol::string_piece_to_buffer_chain(
+  int rc = string_piece_to_buffer_chain(
       request_->pool, buffer_, link_ptr, done_called_ /* send_last_buf */);
   if (rc != NGX_OK) {
     return rc;
@@ -112,8 +112,8 @@ ngx_int_t NgxBaseFetch::CollectHeaders(ngx_http_headers_out_t* headers_out) {
   //   headers_out->content_length_n = content_length();
   // }
 
-  return ngx_psol::copy_response_headers_to_ngx(request_, *pagespeed_headers,
-                                                modify_caching_headers_);
+  return copy_response_headers_to_ngx(request_, *pagespeed_headers,
+                                      modify_caching_headers_);
 }
 
 void NgxBaseFetch::RequestCollection() {

--- a/src/ngx_caching_headers.cc
+++ b/src/ngx_caching_headers.cc
@@ -28,13 +28,11 @@ bool NgxCachingHeaders::Lookup(const GoogleString& key,
   ngx_table_elt_t* header;
   NgxListIterator it(&(request_->headers_out.headers.part));
   while ((header = it.Next()) != NULL) {
-    if (header->hash != 0 &&
-        key == ngx_psol::str_to_string_piece(header->key)) {
+    if (header->hash != 0 && key == str_to_string_piece(header->key)) {
       // This will be called multiple times if there are multiple headers with
       // this name.  Each time it will append to values.
-      SplitStringPieceToVector(
-          ngx_psol::str_to_string_piece(header->value), ",", values,
-                                        true /* omit empty strings */);
+      SplitStringPieceToVector(str_to_string_piece(header->value), ",", values,
+                               true /* omit empty strings */);
     }
   }
 

--- a/src/ngx_pagespeed.h
+++ b/src/ngx_pagespeed.h
@@ -46,9 +46,6 @@ class RewriteDriver;
 class RequestHeaders;
 class ResponseHeaders;
 class InPlaceResourceRecorder;
-}  // namespace net_instaweb
-
-namespace ngx_psol {
 
 // Allocate chain links and buffers from the supplied pool, and copy over the
 // data from the string piece.  If the string piece is empty, return
@@ -79,7 +76,7 @@ StringPiece str_to_string_piece(ngx_str_t s);
 char* string_piece_to_pool_string(ngx_pool_t* pool, StringPiece sp);
 
 typedef struct {
-  net_instaweb::NgxBaseFetch* base_fetch;
+  NgxBaseFetch* base_fetch;
 
   ngx_connection_t* pagespeed_connection;
   ngx_http_request_t* r;
@@ -92,25 +89,25 @@ typedef struct {
   bool modify_caching_headers;
 
   // for html rewrite
-  net_instaweb::ProxyFetch* proxy_fetch;
-  net_instaweb::GzipInflater* inflater_;
+  ProxyFetch* proxy_fetch;
+  GzipInflater* inflater_;
 
   // for in place resource
-  net_instaweb::RewriteDriver* driver;
-  net_instaweb::InPlaceResourceRecorder* recorder;
+  RewriteDriver* driver;
+  InPlaceResourceRecorder* recorder;
 } ps_request_ctx_t;
 
 
 void copy_request_headers_from_ngx(const ngx_http_request_t* r,
-       net_instaweb::RequestHeaders* headers);
+                                   RequestHeaders* headers);
 
 void copy_response_headers_from_ngx(const ngx_http_request_t* r,
-       net_instaweb::ResponseHeaders* headers);
+                                    ResponseHeaders* headers);
 
-ngx_int_t copy_response_headers_to_ngx(
-            ngx_http_request_t* r,
-            const net_instaweb::ResponseHeaders& pagespeed_headers,
-            bool modify_caching_headers);
-}  // namespace ngx_psol
+ngx_int_t copy_response_headers_to_ngx(ngx_http_request_t* r,
+                                       const ResponseHeaders& pagespeed_headers,
+                                       bool modify_caching_headers);
+
+}  // namespace net_instaweb
 
 #endif  // NGX_PAGESPEED_H_

--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -241,7 +241,7 @@ const char* NgxRewriteOptions::ParseAndSetOptions(
         StrAppend(&full_directive, i == 0 ? "" : " ", args[i]);
       }
       StrAppend(&full_directive, "\": ", msg);
-      char* s = ngx_psol::string_piece_to_pool_string(pool, full_directive);
+      char* s = string_piece_to_pool_string(pool, full_directive);
       if (s == NULL) {
         return "failed to allocate memory";
       }

--- a/src/ngx_server_context.cc
+++ b/src/ngx_server_context.cc
@@ -73,7 +73,7 @@ SystemRequestContext* NgxServerContext::NewRequestContext(
   return new SystemRequestContext(thread_system()->NewMutex(),
                                   timer(),
                                   local_port,
-                                  ngx_psol::str_to_string_piece(local_ip));
+                                  str_to_string_piece(local_ip));
 }
 
 }  // namespace net_instaweb


### PR DESCRIPTION
Get rid of net_instaweb:: everywhere.  By eliminating the ngx_psol namespace we
can stop prefixing everything in ngx_pagespeed.cc with net_instaweb::

Fix other minor style issues.

Remove unnecessary declarations.

Rename ps_create_request_context to ps_route_request and CreateRequestContext to
RequestRouting because it no longer creates the request context.
