### PR TITLE
trunk-tracking: update to r3485

### DIFF
--- a/src/ngx_caching_headers.cc
+++ b/src/ngx_caching_headers.cc
@@ -23,7 +23,7 @@
 
 namespace net_instaweb {
 
-bool NgxCachingHeaders::Lookup(const GoogleString& key,
+bool NgxCachingHeaders::Lookup(const StringPiece& key,
                                StringPieceVector* values) {
   ngx_table_elt_t* header;
   NgxListIterator it(&(request_->headers_out.headers.part));

--- a/src/ngx_caching_headers.h
+++ b/src/ngx_caching_headers.h
@@ -37,7 +37,7 @@ class NgxCachingHeaders : public CachingHeaders {
         request_(request) {
   }
 
-  virtual bool Lookup(const GoogleString& key, StringPieceVector* values);
+  virtual bool Lookup(const StringPiece& key, StringPieceVector* values);
 
   virtual bool IsLikelyStaticResourceType() const {
     DCHECK(false);  // not called in our use-case.

--- a/src/ngx_rewrite_options.h
+++ b/src/ngx_rewrite_options.h
@@ -104,9 +104,9 @@ class NgxRewriteOptions : public SystemRewriteOptions {
   void Init();
 
   // Add an option to ngx_properties_
-  template<class RewriteOptionsSubclass, class OptionClass>
+  template<class OptionClass>
   static void add_ngx_option(typename OptionClass::ValueType default_value,
-                             OptionClass RewriteOptionsSubclass::*offset,
+                             OptionClass NgxRewriteOptions::*offset,
                              const char* id,
                              StringPiece option_name) {
     AddProperty(default_value, offset, id, option_name, ngx_properties_);

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -547,6 +547,19 @@ http {
   }
 
   server {
+    listen @@SECONDARY_PORT@@;
+    server_name ipro.example.com;
+    pagespeed FileCachePath "@@SECONDARY_CACHE@@";
+
+    pagespeed on;
+    pagespeed InPlaceResourceOptimization on;
+
+    location /mod_pagespeed_test/ipro/nocache/test_image_dont_reuse.png {
+      add_header Cache-Control no-cache;
+    }
+  }
+
+  server {
     listen       @@PRIMARY_PORT@@;
     server_name  localhost;
     pagespeed FileCachePath "@@FILE_CACHE@@";
@@ -705,7 +718,6 @@ http {
     location /mod_pagespeed_test/ipro/test_image_dont_reuse.png {
       expires 5m;
     }
-
 
     pagespeed EnableFilters remove_comments;
 


### PR DESCRIPTION
- Adds IPRO tests that we should have copied from apache_system_test.sh back
  when we first added IPRO.
  - The "IPRO-optimized resources should have fixed size, not chunked" test
    fails.  The problem is as it says: IPRO optimized resources are being sent
    out with `Transfer-Encoding: Chunked` instead of `Content-Length: ...`.  How
    do we fix this?
- install/system_test.sh moved to net/instaweb/automatic/system_test.sh
- minor method signature changes
- url.is_valid() is gone, replaced by .IsWebValid()
- I pushed Otto's #464 upstream, and now we need to make some IPRO changes.
- beacons have nonces now, so we need to update tests.
