### PR TITLE
reloading: backport reloading fix

### DIFF
--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -249,6 +249,9 @@ bool NgxRewriteDriverFactory::CheckResolver() {
 }
 
 void NgxRewriteDriverFactory::StopCacheActivity() {
+  if (is_root_process_) {
+    return;  // No caches used in root process.
+  }
   RewriteDriverFactory::StopCacheActivity();
   caches_->StopCacheActivity();
 }

--- a/src/ngx_thread_system.cc
+++ b/src/ngx_thread_system.cc
@@ -29,7 +29,7 @@ NgxThreadSystem::NgxThreadSystem() : may_start_threads_(false) {}
 NgxThreadSystem::~NgxThreadSystem() {}
 
 void NgxThreadSystem::PermitThreadStarting() {
-  CHECK(!may_start_threads_);
+  DCHECK(!may_start_threads_);
   may_start_threads_ = true;
 }
 
@@ -40,7 +40,7 @@ void NgxThreadSystem::BeforeThreadRunHook() {
 
   // If this fails you can get a backtrace from gdb by setting a breakpoint on
   // "pthread_create".
-  CHECK(may_start_threads_);
+  DCHECK(may_start_threads_);
 }
 
 }  // namespace net_instaweb


### PR DESCRIPTION
Issue #364 was fixed upstream in [r3492](http://code.google.com/p/modpagespeed/source/detail?r=3492).  Backport the fix to master.

"We only need to shut down the caches in child processes because they are not
started in the master process.  This wasn't a problem before, but shutting down
the caches can start a thread which isn't safe to do in the master process of a
forking server like Nginx."

Also backport the change from [r3497](http://code.google.com/p/modpagespeed/source/detail?r=3497) where we use a DCHECK for
may_start_threads_.  It's bad to start threads in the root process, but it's not
worth crashing a production server over.
