### PR TITLE
Use net_instaweb::ProcessContext

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -178,7 +178,7 @@ check_not_simple grep @@ $PAGESPEED_CONF
 # start nginx with new config
 if $USE_VALGRIND; then
   echo "Run this command in another terminal and then press enter:"
-  echo "  valgrind $NGINX_EXECUTABLE -c $PAGESPEED_CONF"
+  echo "  valgrind --leak-check=full $NGINX_EXECUTABLE -c $PAGESPEED_CONF"
   read
 else
   TRACE_FILE="$TEST_TMP/conf_loading_trace"


### PR DESCRIPTION
This fixes a few valgrind errors on shutdown , plus a potential
issue when url_util.cc would lazily initialize in a thread-unsafe
manner. Also adds --leak-check=full to the suggested valgrind
command for the system tests.
