### PR TITLE
trunk-tracking: update to r3508

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -1456,6 +1456,12 @@ void ps_release_request_context(void* data) {
     ctx->driver = NULL;
   }
 
+  if (ctx->recorder != NULL) {
+    ctx->recorder->Fail();
+    ctx->recorder->DoneAndSetHeaders();  // Deletes recorder.
+    ctx->recorder = NULL;
+  }
+
   ps_release_base_fetch(ctx);
   delete ctx;
 }
@@ -1586,6 +1592,7 @@ ngx_int_t ps_resource_handler(ngx_http_request_t* r, bool html_rewrite) {
     ctx->pagespeed_connection = NULL;
     // See build_context_for_request() in mod_instaweb.cc
     ctx->modify_caching_headers = options->modify_caching_headers();
+    ctx->recorder = NULL;
 
     // Set up a cleanup handler on the request.
     ngx_http_cleanup_t* cleanup = ngx_http_cleanup_add(r, 0);


### PR DESCRIPTION
No major changes that we need to be compatible with.  r3508 tweaks
InPlaceResourceRecorder::DoneAndSetHeaders so that we can now make sure to
release it: the recorder is allocated in ps_in_place_check_header_filter and
released in ps_in_place_body_filter, but if there's an error in between it will
be leaked.  We know ps_release_request_context will get run regardless because
it's set as a cleanup handler, so clean up the recorder there.

Fixes #527
