### PR TITLE
logging: fix use-after-free

### DIFF
--- a/src/ngx_message_handler.h
+++ b/src/ngx_message_handler.h
@@ -54,6 +54,7 @@ class NgxMessageHandler : public GoogleMessageHandler {
   // Messages logged before that will be passed on to handler_;
   void set_buffer(SharedCircularBuffer* buff);
   void set_log(ngx_log_t* log) { log_ = log; }
+  ngx_log_t* log() { return log_; }
 
   void SetPidString(const int64 pid) {
     pid_string_ = StrCat("[", Integer64ToString(pid), "]");

--- a/src/ngx_server_context.h
+++ b/src/ngx_server_context.h
@@ -21,6 +21,7 @@
 #ifndef NGX_SERVER_CONTEXT_H_
 #define NGX_SERVER_CONTEXT_H_
 
+#include "ngx_message_handler.h"
 #include "net/instaweb/system/public/system_server_context.h"
 
 extern "C" {
@@ -49,6 +50,10 @@ class NgxServerContext : public SystemServerContext {
 
   NgxRewriteDriverFactory* ngx_rewrite_driver_factory() { return ngx_factory_; }
   SystemRequestContext* NewRequestContext(ngx_http_request_t* r);
+
+  NgxMessageHandler* ngx_message_handler() {
+    return dynamic_cast<NgxMessageHandler*>(message_handler());
+  }
 
  private:
   NgxRewriteDriverFactory* ngx_factory_;


### PR DESCRIPTION
The `pagespeed_connection` needs a log to write to, but unfortunately `r->connection->log` isn't guaranteed to still be around for the whole lifetime of the `pagespeed_connection`.  Use the log from the server context instead.

Fixes issue #522.
