### PR TITLE
pipe-cleanup: Change the way in which we cleanup pipes

### DIFF
--- a/src/ngx_base_fetch.h
+++ b/src/ngx_base_fetch.h
@@ -97,7 +97,7 @@ class NgxBaseFetch : public AsyncFetch {
 
   // Indicate to nginx that we would like it to call
   // CollectAccumulatedWrites().
-  void RequestCollection();
+  void RequestCollection(bool done);
 
   // Lock must be acquired first.
   // Returns:


### PR DESCRIPTION
- Ignore errors at the write-end of the pipe when the associated
  request context has been released, to avoid filling the log with
  messages about broken pipes for aborted requests (which is not
  uncommon)
- Explicitly signal the read end of the pipe to close its end of
  the pipe, and ignore reading 0 bytes from the pipe. Add locking
  here as well.

Attempts to fix:
https://github.com/pagespeed/ngx_pagespeed/issues/390
https://github.com/pagespeed/ngx_pagespeed/issues/509
