### PR TITLE
trunk-tracking: update to 1.7.30.1 from r3581

### DIFF
--- a/src/ngx_base_fetch.cc
+++ b/src/ngx_base_fetch.cc
@@ -31,7 +31,7 @@ namespace net_instaweb {
 NgxBaseFetch::NgxBaseFetch(ngx_http_request_t* r, int pipe_fd,
                            NgxServerContext* server_context,
                            const RequestContextPtr& request_ctx,
-                           bool modify_caching_headers)
+                           PreserveCachingHeaders preserve_caching_headers)
     : AsyncFetch(request_ctx),
       request_(r),
       server_context_(server_context),
@@ -40,7 +40,7 @@ NgxBaseFetch::NgxBaseFetch(ngx_http_request_t* r, int pipe_fd,
       pipe_fd_(pipe_fd),
       references_(2),
       handle_error_(true),
-      modify_caching_headers_(modify_caching_headers) {
+      preserve_caching_headers_(preserve_caching_headers) {
   if (pthread_mutex_init(&mutex_, NULL)) CHECK(0);
 }
 
@@ -113,7 +113,7 @@ ngx_int_t NgxBaseFetch::CollectHeaders(ngx_http_headers_out_t* headers_out) {
   // }
 
   return copy_response_headers_to_ngx(request_, *pagespeed_headers,
-                                      modify_caching_headers_);
+                                      preserve_caching_headers_);
 }
 
 void NgxBaseFetch::RequestCollection() {

--- a/src/ngx_base_fetch.h
+++ b/src/ngx_base_fetch.h
@@ -58,7 +58,7 @@ class NgxBaseFetch : public AsyncFetch {
   NgxBaseFetch(ngx_http_request_t* r, int pipe_fd,
                NgxServerContext* server_context,
                const RequestContextPtr& request_ctx,
-               bool modify_caching_headers);
+               PreserveCachingHeaders preserve_caching_headers);
   virtual ~NgxBaseFetch();
 
   // Puts a chain in link_ptr if we have any output data buffered.  Returns
@@ -118,7 +118,7 @@ class NgxBaseFetch : public AsyncFetch {
   int references_;
   pthread_mutex_t mutex_;
   bool handle_error_;
-  bool modify_caching_headers_;
+  PreserveCachingHeaders preserve_caching_headers_;
 
   DISALLOW_COPY_AND_ASSIGN(NgxBaseFetch);
 };

--- a/src/ngx_pagespeed.h
+++ b/src/ngx_pagespeed.h
@@ -75,6 +75,12 @@ StringPiece str_to_string_piece(ngx_str_t s);
 // over.  Returns NULL if we can't get memory.
 char* string_piece_to_pool_string(ngx_pool_t* pool, StringPiece sp);
 
+enum PreserveCachingHeaders {
+  kPreserveAllCachingHeaders,  // Cache-Control, ETag, Last-Modified, etc
+  kPreserveOnlyCacheControl,   // Only Cache-Control.
+  kDontPreserveHeaders,
+};
+
 typedef struct {
   NgxBaseFetch* base_fetch;
 
@@ -86,7 +92,8 @@ typedef struct {
 
   bool write_pending;
   bool fetch_done;
-  bool modify_caching_headers;
+
+  PreserveCachingHeaders preserve_caching_headers;
 
   // for html rewrite
   ProxyFetch* proxy_fetch;
@@ -105,9 +112,10 @@ void copy_request_headers_from_ngx(const ngx_http_request_t* r,
 void copy_response_headers_from_ngx(const ngx_http_request_t* r,
                                     ResponseHeaders* headers);
 
-ngx_int_t copy_response_headers_to_ngx(ngx_http_request_t* r,
-                                       const ResponseHeaders& pagespeed_headers,
-                                       bool modify_caching_headers);
+ngx_int_t copy_response_headers_to_ngx(
+    ngx_http_request_t* r,
+    const ResponseHeaders& pagespeed_headers,
+    PreserveCachingHeaders preserve_caching_headers);
 
 }  // namespace net_instaweb
 

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -563,6 +563,58 @@ http {
     }
   }
 
+  # Test hosts to cover all possible cache configurations.  L1 will be filecache
+  # or memcache depending on the setting of MEMCACHED_TEST.  These four hosts
+  # are for the four settings for the L2 cache.
+
+  # 1. L2_d=LRU, L2_m=LRU
+  server {
+    listen @@SECONDARY_PORT@@;
+    server_name lrud-lrum.example.com;
+    pagespeed FileCachePath "@@SECONDARY_CACHE@@_lrud_lrum";
+
+    pagespeed LRUCacheKbPerProcess 1024;
+    pagespeed LRUCacheByteLimit 2000;
+    pagespeed EnableFilters rewrite_images;
+    pagespeed CriticalImagesBeaconEnabled false;
+  }
+
+  # 2. L2_d=LRU, L2_m=SHM
+  pagespeed CreateSharedMemoryMetadataCache
+            "@@SECONDARY_CACHE@@_lrud_shmm" 8192;
+  server {
+    listen @@SECONDARY_PORT@@;
+    server_name lrud-shmm.example.com;
+    pagespeed FileCachePath "@@SECONDARY_CACHE@@_lrud_shmm";
+
+    pagespeed LRUCacheKbPerProcess 1024;
+    pagespeed LRUCacheByteLimit 2000;
+    pagespeed EnableFilters rewrite_images;
+    pagespeed CriticalImagesBeaconEnabled false;
+  }
+
+  # 3. L2_d=none, L2_m=SHM
+  pagespeed CreateSharedMemoryMetadataCache
+            "@@SECONDARY_CACHE@@_noned_shmm" 8192;
+  server {
+    listen @@SECONDARY_PORT@@;
+    server_name noned-shmm.example.com;
+    pagespeed FileCachePath "@@SECONDARY_CACHE@@_noned_shmm";
+
+    pagespeed EnableFilters rewrite_images;
+    pagespeed CriticalImagesBeaconEnabled false;
+  }
+
+  # 4. L2_d=none, L2_m=none
+  server {
+    listen @@SECONDARY_PORT@@;
+    server_name noned-nonem.example.com;
+    pagespeed FileCachePath "@@SECONDARY_CACHE@@_noned_nonem";
+
+    pagespeed EnableFilters rewrite_images;
+    pagespeed CriticalImagesBeaconEnabled false;
+  }
+
   server {
     listen       @@PRIMARY_PORT@@;
     server_name  localhost;
@@ -708,6 +760,12 @@ http {
 
     location /mod_pagespeed_test/retain_cache_control/ {
       pagespeed ModifyCachingHeaders off;
+      add_header Cache-Control "private, max-age=3000";
+    }
+
+    location /mod_pagespeed_test/retain_cache_control_with_downstream_caching/ {
+      pagespeed ModifyCachingHeaders on;
+      pagespeed DownstreamCachePurgeLocationPrefix "http://localhost:8020/";
       add_header Cache-Control "private, max-age=3000";
     }
 


### PR DESCRIPTION
Changes:
- r3585: With downstream caching, don't touch `Cache-Control` headers.
  - No longer require `Modify Caching Headers off`.
  - Change from `modify_caching_headers` as a boolean to a three valued enum
    `PreserveCachingHeaders`.
- r3596: Make tests less flaky.
  - Changes WGET_DUMP to write to WGET_DIR instead of OUTDIR.
- r3597: Remove now-redundant system tests.
  - Some system tests were moved into `automatic/system_test.sh` which means we
    can remove our forks.
- r3598: Enable the shared memory metadata cache by default.
  - The code change just worked and needed no changes, but it also added
    substantial tests, which needed some porting.
- Deflake the `scrape stats` test by moving it before config reloading.
