### PR TITLE
system-test: increase timeout for keepalive tests from 1s to 2s

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -69,11 +69,11 @@ function keepalive_test() {
   for ((i=0; i < 100; i++)); do
     for accept_encoding in "" "gzip"; do
       if [ -z "$POST_DATA" ]; then
-      curl -m 1 -S -s -v -H "Accept-Encoding: $accept_encoding" \
+        curl -m 2 -S -s -v -H "Accept-Encoding: $accept_encoding" \
           -H "Host: $HOST_NAME" $URL $URL $URL $URL $URL > /dev/null \
           2>>"$TEST_TMP/$CURL_LOG_FILE"
       else
-        curl -X POST --data "$POST_DATA" -m 1 -S -s -v \
+        curl -X POST --data "$POST_DATA" -m 2 -S -s -v \
           -H "Accept-Encoding: $accept_encoding" -H "Host: $HOST_NAME"\
           $URL $URL $URL $URL $URL > /dev/null \
           2>>"$TEST_TMP/$CURL_LOG_FILE"


### PR DESCRIPTION
The keepalive tests were occasionally bumping up against
the 1s timeout we had set for curl, but a 1s 99.9% tail
latency is a little agressive.  Drop it to 2s to make the
tests less flaky.

What we really need is a proper load testing setup, so
the keepalive test isn't doing double-duty.
