### PR TITLE
messages: unbreak /ngx_pagespeed_messages

### DIFF
--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -218,6 +218,8 @@ void NgxRewriteDriverFactory::LoggingInit(ngx_log_t* log) {
 void NgxRewriteDriverFactory::SetCircularBuffer(
     SharedCircularBuffer* buffer) {
   ngx_shared_circular_buffer_ = buffer;
+  ngx_message_handler_->set_buffer(buffer);
+  ngx_html_parse_message_handler_->set_buffer(buffer);
 }
 
 void NgxRewriteDriverFactory::SetServerContextMessageHandler(

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -2010,7 +2010,7 @@ check_not_from "$(extract_headers $FETCH_UNTIL_OUTFILE)" \
 # that we bail out of parsing and insert a script redirecting to
 # ?PageSpeed=off. This should also insert an entry into the property cache so
 # that the next time we fetch the file it will not be parsed at all.
-echo TEST: Handling of large files.
+start_test Handling of large files.
 # Add a timestamp to the URL to ensure it's not in the property cache.
 FILE="max_html_parse_size/large_file.html?value=$(date +%s)"
 URL=$TEST_ROOT/$FILE
@@ -2029,5 +2029,9 @@ check_from "$LARGE_OUT" grep -q window.location=".*&ModPagespeed=off"
 fetch_until -save $URL 'grep -c window.location=".*&ModPagespeed=off"' 0
 check_not fgrep -q pagespeed.ic $FETCH_FILE
 
+start_test messages load
+OUT=$($WGET_DUMP "$HOSTNAME/ngx_pagespeed_message")
+check_not_from "$OUT" grep "Writing to ngx_pagespeed_message failed."
+check_from "$OUT" grep -q "/mod_pagespeed_example"
 
 check_failures_and_exit

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -649,6 +649,7 @@ http {
     #pagespeed MemcachedThreads 1;
 
     pagespeed on;
+    pagespeed MessageBufferSize 200000;
 
     #pagespeed CacheFlushPollIntervalSec 1;
 
@@ -664,9 +665,6 @@ http {
     # the value of BlockingRewriteKey below, the response will be fully
     # rewritten before being flushed to the client.
     pagespeed BlockingRewriteKey psatest;
-
-    # Disable parsing if the size of the HTML exceeds 50kB.
-    pagespeed MaxHtmlParseBytes 50000;
 
     add_header X-Extra-Header 1;
 
@@ -704,6 +702,10 @@ http {
       pagespeed ForbidAllDisabledFilters true;
       pagespeed DisableFilters remove_quotes,remove_comments;
       pagespeed DisableFilters collapse_whitespace;
+    }
+
+    location /mod_pagespeed_test/max_html_parse_size {
+      pagespeed MaxHtmlParseBytes 5000;
     }
 
     location ~ \.php$ {


### PR DESCRIPTION
The shared circular buffer wasn't hooked up fully, which meant loading `/ngx_pagespeed_messages` didn't work.  This fixes that and adds a test.

I also noticed while adding this that the 'Handling of large files' test wasn't set up properly, so I converted that to use start_test.

Fixing that exposed another bug where the 'Handling of large files' test was actually failing but being marked as an expected failure by being grouped in with the test above.  Adding `pagespeed MaxHtmlParseBytes 5000` to the appropriate location made it test what it was supposed to be testing again, and the underlying feature wasn't broken.

Fixes #559 
