### PR TITLE
trunk-tracking: update to r3632 from 1.7.30.1

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -2159,7 +2159,8 @@ ngx_int_t ps_in_place_check_header_filter(ngx_http_request_t* r) {
     return ngx_http_next_header_filter(r);
   }
 
-  if (status_code == CacheUrlAsyncFetcher::kNotInCacheStatus) {
+  if (status_code == CacheUrlAsyncFetcher::kNotInCacheStatus &&
+      !r->header_only) {
     server_context->rewrite_stats()->ipro_not_in_cache()->Add(1);
     server_context->message_handler()->Message(
         kInfo,


### PR DESCRIPTION
Port [r3631](https://code.google.com/p/modpagespeed/source/detail?r=3631): "Fix interaction of IPRO with some other modules which may not behave 100% by the book."
