### PR TITLE
Add proxy support to native fetcher

### DIFF
--- a/src/ngx_fetch.h
+++ b/src/ngx_fetch.h
@@ -44,8 +44,7 @@ typedef bool (*response_handler_pt)(ngx_connection_t* c);
 class NgxUrlAsyncFetcher;
 class NgxFetch : public PoolElement<NgxFetch> {
  public:
-  NgxFetch(ngx_url_t proxy,
-           const GoogleString& url,
+  NgxFetch(const GoogleString& url,
            AsyncFetch* async_fetch,
            MessageHandler* message_handler,
            ngx_msec_t timeout_ms,
@@ -116,7 +115,6 @@ class NgxFetch : public PoolElement<NgxFetch> {
   void FixUserAgent();
   void FixHost();
 
-  ngx_url_t proxy_url_;
   const GoogleString str_url_;
   ngx_url_t url_;
   NgxUrlAsyncFetcher* fetcher_;

--- a/src/ngx_url_async_fetcher.cc
+++ b/src/ngx_url_async_fetcher.cc
@@ -222,7 +222,7 @@ namespace net_instaweb {
                                  MessageHandler* message_handler,
                                  AsyncFetch* async_fetch) {
     async_fetch = EnableInflation(async_fetch, NULL);
-    NgxFetch* fetch = new NgxFetch(proxy_, url, async_fetch,
+    NgxFetch* fetch = new NgxFetch(url, async_fetch,
           message_handler, fetch_timeout_, log_);
     ScopedMutex lock(mutex_);
     pending_fetches_.Add(fetch);


### PR DESCRIPTION
Example:
    pagespeed FetchProxy        127.0.0.1:8081;
    pagespeed FetchProxy        www.proxy.com:8081:

By replace the ip address which nginx connect to with the ip address of the proxy server and replace the dns name nginx take to resolve with the dns name of the proxy server, we manage to pass all the fetch traffic to the proxy server. BTW, i am not very familiar with http proxy and github, so careful review is needed ^_^
