### PR TITLE
Added a missing 'cd ~' command to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ recompiling Tengine](https://github.com/pagespeed/ngx_pagespeed/wiki/Using-ngx_p
 3. Download and build nginx:
 
    ```bash
+   $ cd ~
    $ # check http://nginx.org/en/download.html for the latest version
    $ wget http://nginx.org/download/nginx-1.4.4.tar.gz
    $ tar -xvzf nginx-1.4.4.tar.gz


### PR DESCRIPTION
I believe that the section, "3. Download and build nginx:" should start with $ cd ~ 
