### PR TITLE
Date header: use current date when we don't get one handed over

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -244,6 +244,13 @@ void copy_response_headers_from_ngx(const ngx_http_request_t* r,
   headers->Add(HttpAttributes::kContentType,
                str_to_string_piece(r->headers_out.content_type));
 
+  // When we don't have a date header, invent one.
+  const char* date = headers->Lookup1(HttpAttributes::kDate);
+  
+  if (date == NULL) {
+    headers->SetDate(ngx_current_msec);
+  }
+  
   // TODO(oschaaf): ComputeCaching should be called in setupforhtml()?
   headers->ComputeCaching();
 }

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -2073,6 +2073,14 @@ curl -vv -m 2 http://$PRIMARY_HOSTNAME/foo.css.pagespeed.ce.0.css \
     -H 'If-Modified-Since: Z' http://$PRIMARY_HOSTNAME/foo
 check [ $? = "0" ]
 
+start_test Date response header set
+OUT=$($WGET_DUMP $EXAMPLE_ROOT/combine_css.html)
+check_not_from "$OUT" egrep -q '^Date: Thu, 01 Jan 1970 00:00:00 GMT'
+
+OUT=$($WGET_DUMP --header=Host:date.example.com \
+    http://$SECONDARY_HOSTNAME/mod_pagespeed_example/combine_css.html)
+check_from "$OUT" egrep -q '^Date: Fri, 16 Oct 2009 23:05:07 GMT'
+
 if $USE_VALGRIND; then
     kill -s quit $VALGRIND_PID
     wait

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -616,6 +616,13 @@ http {
   }
 
   server {
+    listen @@SECONDARY_PORT@@;
+    server_name date.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    add_header "Date" "Date: Fri, 16 Oct 2009 23:05:07 GMT";
+  }
+
+  server {
     listen       @@PRIMARY_PORT@@;
     server_name  localhost;
     pagespeed FileCachePath "@@FILE_CACHE@@";


### PR DESCRIPTION
When the content generator does not supply us with a date header,
we need to create one ourselves and set it to the current date.

Fixes:
https://github.com/pagespeed/ngx_pagespeed/issues/604 (duplicate)
https://github.com/pagespeed/ngx_pagespeed/issues/577
