### PR TITLE
Trunk tracking tests: Fixes to pass the system tests

### DIFF
--- a/src/ngx_fetch.h
+++ b/src/ngx_fetch.h
@@ -121,12 +121,13 @@ class NgxFetch : public PoolElement<NgxFetch> {
   AsyncFetch* async_fetch_;
   ResponseHeadersParser parser_;
   MessageHandler* message_handler_;
-  size_t bytes_received_;
+  int64 bytes_received_;
   int64 fetch_start_ms_;
   int64 fetch_end_ms_;
   int64 timeout_ms_;
   bool done_;
   int64 content_length_;
+  bool content_length_known_;
 
   struct sockaddr_in sin_;
   ngx_log_t* log_;

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -833,6 +833,7 @@ function test_optimize_for_bandwidth() {
     check_from "$OUT" grep -q "$3"
   fi
 }
+
 test_optimize_for_bandwidth rewrite_css.html \
   '.blue{foreground-color:blue}body{background:url(arrow.png)}' \
   '<link rel="stylesheet" type="text/css" href="yellow.css">'
@@ -2106,7 +2107,7 @@ CONNECTION=$(extract_headers $FETCH_UNTIL_OUTFILE | fgrep "Connection:")
 check_not_from "$CONNECTION" fgrep -qi "Keep-Alive, Keep-Alive"
 check_from "$CONNECTION" fgrep -qi "Keep-Alive"
 
-test_filter ngx_pagespeed_static defer js served with correct headers.
+start_test ngx_pagespeed_static defer js served with correct headers.
 # First, determine which hash js_defer is served with. We need a correct hash
 # to get it served up with an Etag, which is one of the things we want to test.
 URL="$HOSTNAME/mod_pagespeed_example/defer_javascript.html?PageSpeed=on&PageSpeedFilters=defer_javascript"
@@ -2310,6 +2311,10 @@ OUT=$($WGET_DUMP --header=Host:date.example.com \
 check_from "$OUT" egrep -q '^Date: Fri, 16 Oct 2009 23:05:07 GMT'
 
 if $USE_VALGRIND; then
+    # It is possible that there are still ProxyFetches outstanding
+    # at this point in time. Give them a few extra seconds to allow
+    # them to finish, so they will not generate valgrind complaints
+    sleep 3
     kill -s quit $VALGRIND_PID
     wait
     # Clear the previously set trap, we don't need it anymore.

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -32,6 +32,7 @@ http {
   pagespeed InPlaceResourceOptimization on;
   pagespeed CreateSharedMemoryMetadataCache "@@SHM_CACHE@@" 8192;
   pagespeed PreserveUrlRelativity on;
+  pagespeed BlockingRewriteKey psatest;
 
   # CriticalImagesBeaconEnabled is now on by default, but we disable in testing.
   # With this option enabled, the inline image system test will currently fail.
@@ -53,7 +54,6 @@ http {
     server_name max-cacheable-content-length.example.com;
     pagespeed FileCachePath "@@FILE_CACHE@@";
 
-    pagespeed BlockingRewriteKey psatest;
 
     pagespeed RewriteLevel PassThrough;
     pagespeed EnableFilters rewrite_javascript;
@@ -275,7 +275,8 @@ http {
     pagespeed on;
     pagespeed RewriteLevel PassThrough;
     pagespeed EnableFilters rewrite_images;
-    pagespeed MapOriginDomain localhost:@@SECONDARY_PORT@@/customhostheader
+    # Don't use localhost, as ngx_pagespeed's native fetcher cannot resolve it
+    pagespeed MapOriginDomain 127.0.0.1:@@SECONDARY_PORT@@/customhostheader
               sharedcdn.example.com/test customhostheader.example.com;
     pagespeed JpegRecompressionQuality 50;
     pagespeed CriticalImagesBeaconEnabled false;
@@ -288,7 +289,6 @@ http {
     server_name forbidden.example.com;
     pagespeed FileCachePath "@@FILE_CACHE@@";
 
-    pagespeed BlockingRewriteKey psatest;
 
     # Start with all core filters enabled ...
     pagespeed RewriteLevel CoreFilters;
@@ -572,7 +572,6 @@ http {
     server_name blocking.example.com;
     pagespeed FileCachePath "@@SECONDARY_CACHE@@";
 
-    pagespeed BlockingRewriteKey psatest;
     pagespeed RewriteLevel PassThrough;
     pagespeed EnableFilters rewrite_images;
   }
@@ -748,11 +747,6 @@ http {
 
     pagespeed Library 43 1o978_K0_LNE5_ystNklf
     http://www.modpagespeed.com/rewrite_javascript.js;
-
-    # If X-PSA-Blocking-Rewrite request header is present and its value matches
-    # the value of BlockingRewriteKey below, the response will be fully
-    # rewritten before being flushed to the client.
-    pagespeed BlockingRewriteKey psatest;
 
     add_header X-Extra-Header 1;
 

--- a/test/valgrind.sup
+++ b/test/valgrind.sup
@@ -120,3 +120,46 @@
    fun:ngx_start_worker_processes
    fun:ngx_master_process_cycle
 }
+
+# Extra suppresions for testing in release mode:
+
+{
+   <re2 uninitialised value in optimized code>
+   Memcheck:Cond
+   fun:_ZN3re24Prog8OptimizeEv
+   ...
+}
+{
+   <re2 uninitialised value in optimized code>
+   Memcheck:Value8
+   fun:_ZN3re24Prog8OptimizeEv
+   ...
+}
+
+{
+   <re2 uninitialised value in optimized code>
+   Memcheck:Cond
+   fun:_ZN3re2L4AddQEPNS_9SparseSetEi
+   ...
+}
+
+{
+   <re2 uninitialised value in optimized code>
+   Memcheck:Value8
+   fun:_ZN3re2L4AddQEPNS_9SparseSetEi
+   ...
+}
+
+{
+   <re2 uninitialized value in optimized code>
+   Memcheck:Value8
+   fun:_ZN3re23DFA10AddToQueueEPNS0_5WorkqEij
+   ...
+}
+
+{
+   <re2 uninitialized value in optimized code>
+   Memcheck:Cond
+   fun:_ZN3re23DFA10AddToQueueEPNS0_5WorkqEij
+   ...
+}


### PR DESCRIPTION
A few fixes to help making the trunk tracking update from r3715 to
r3736 pass the system tests with the native fetcher and under
valgrind.
- Native fetcher: fortify handling of content lenght (and absense)
- Native fetcher: fail when the stream terminates before having
                completely parsed the headers
- Tests: Rename test_filter -> start_test in ngx_system_test.sh for
       a test
- Tests: Add blockingrewrite key for two tests that need it
- Tests: Update localhost -> 127.0.0.1. The native fetcher uses
       dns to resolve, and won't be able to retreive an ip for
       localhost
- Tests: Allow outstanding proxy fetches some time to finish
       when running under valgrind, before terminating nginx
- Valgrind: Add suppressions to make testing a resealse build pass

Should fix: https://github.com/pagespeed/ngx_pagespeed/issues/609
Might replace https://github.com/pagespeed/ngx_pagespeed/pull/602
