### PR TITLE
trunk-tracking: update from r3770 to r3784

### DIFF
--- a/src/ngx_message_handler.cc
+++ b/src/ngx_message_handler.cc
@@ -148,14 +148,4 @@ void NgxMessageHandler::FileMessageVImpl(MessageType type, const char* file,
   }
 }
 
-// TODO(sligocki): It'd be nice not to do so much string copying.
-GoogleString NgxMessageHandler::Format(const char* msg, va_list args) {
-  GoogleString buffer;
-
-  // Ignore the name of this routine: it formats with vsnprintf.
-  // See base/stringprintf.cc.
-  StringAppendV(&buffer, msg, args);
-  return buffer;
-}
-
 }  // namespace net_instaweb

--- a/src/ngx_message_handler.h
+++ b/src/ngx_message_handler.h
@@ -70,7 +70,6 @@ class NgxMessageHandler : public GoogleMessageHandler {
 
  private:
   ngx_uint_t GetNgxLogLevel(MessageType type);
-  GoogleString Format(const char* msg, va_list args);
 
   scoped_ptr<AbstractMutex> mutex_;
   GoogleString pid_string_;

--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -2124,15 +2124,15 @@ ngx_int_t ps_in_place_check_header_filter(ngx_http_request_t* r) {
         url.c_str());
     const SystemRewriteOptions* options = SystemRewriteOptions::DynamicCast(
         ctx->driver->options());
-    scoped_ptr<RequestHeaders> request_headers(new RequestHeaders);
-    copy_request_headers_from_ngx(r, request_headers.get());
+    RequestHeaders request_headers;
+    copy_request_headers_from_ngx(r, &request_headers);
     // This URL was not found in cache (neither the input resource nor
     // a ResourceNotCacheable entry) so we need to get it into cache
     // (or at least a note that it cannot be cached stored there).
     // We do that using an Apache output filter.
     ctx->recorder = new InPlaceResourceRecorder(
         url,
-        request_headers.release(),
+        request_headers,
         options->respect_vary(),
         options->ipro_max_response_bytes(),
         options->ipro_max_concurrent_recordings(),

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -52,6 +52,11 @@ http {
   # critical images to be inlined, so we just disable the option here.
   pagespeed CriticalImagesBeaconEnabled false;
 
+  # By default, resources will not be used for inlining without explicit
+  # authorization. Supported values are off or a comma-separated list of strings
+  # from {Script,Stylesheet}.
+  pagespeed InlineResourcesWithoutExplicitAuthorization off;
+
   pagespeed Statistics on;
   pagespeed StatisticsLogging on;
   pagespeed LogDir "@@TEST_TMP@@/logdir";
@@ -369,7 +374,7 @@ http {
     pagespeed FileCachePath "@@FILE_CACHE@@";
 
     pagespeed RewriteLevel PassThrough;
-    pagespeed InlineUnauthorizedResourcesExperimental true;
+    pagespeed InlineResourcesWithoutExplicitAuthorization Script,Stylesheet;
     pagespeed CssInlineMaxBytes 1000000;
   }
 


### PR DESCRIPTION
- r3772 changed the format of unauthorized resource inlining config
- r3776 changed query param handling, but due to Jud's nice work in
  #616 needed no changes.
- r3780 huibao's refactoring lets us remove some duplicate code
- r3783 changes header passing with ipro
- Also cleaned up error messages for unknown options.
