### PR TITLE
trunk-tracking: update from r3784 to r3811

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -341,8 +341,6 @@ ngx_int_t copy_response_headers_to_ngx(
     // copy here?
     } else if (STR_EQ_LITERAL(name, "Connection")) {
       continue;
-    } else if (STR_EQ_LITERAL(name, "Vary")) {
-      continue;
     } else if (STR_EQ_LITERAL(name, "Keep-Alive")) {
       continue;
     } else if (STR_EQ_LITERAL(name, "Transfer-Encoding")) {
@@ -672,6 +670,7 @@ void* ps_create_main_conf(ngx_conf_t* cf) {
   NgxRewriteDriverFactory::Initialize();
 
   cfg_m->driver_factory = new NgxRewriteDriverFactory(
+      *process_context,
       new SystemThreadSystem(),
       "" /* hostname, not used */,
       -1 /* port, not used */);
@@ -2134,6 +2133,7 @@ ngx_int_t ps_in_place_check_header_filter(ngx_http_request_t* r) {
         options->respect_vary(),
         options->ipro_max_response_bytes(),
         options->ipro_max_concurrent_recordings(),
+        options->implicit_cache_ttl_ms(),
         server_context->http_cache(),
         server_context->statistics(),
         message_handler);

--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -69,8 +69,9 @@ const char NgxRewriteDriverFactory::kStaticAssetPrefix[] =
 class SharedCircularBuffer;
 
 NgxRewriteDriverFactory::NgxRewriteDriverFactory(
+    const ProcessContext& process_context,
     SystemThreadSystem* system_thread_system, StringPiece hostname, int port)
-    : SystemRewriteDriverFactory(system_thread_system,
+    : SystemRewriteDriverFactory(process_context, system_thread_system,
         NULL /* default shared memory runtime */, hostname, port),
       main_conf_(NULL),
       threads_started_(false),

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -55,6 +55,7 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
 
   // We take ownership of the thread system.
   explicit NgxRewriteDriverFactory(
+      const ProcessContext& process_context,
       SystemThreadSystem* system_thread_system, StringPiece hostname, int port);
   virtual ~NgxRewriteDriverFactory();
   virtual Hasher* NewHasher();

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1980,6 +1980,141 @@ URL="http://customhostheader.example.com/map_origin_host_header.html"
 http_proxy=$SECONDARY_HOSTNAME fetch_until -save "$URL" \
     "grep -c data:image/png;base64" 1
 
+# Optimize in-place images for browser. Ideal test matrix (not covered yet):
+# User-Agent:  Accept:  Image type   Result
+# -----------  -------  ----------   ----------------------------------
+#    IE         N/A     photo        image/jpeg, Cache-Control: private *
+#     :         N/A     synthetic    image/png,  Cache-Control: private *
+#  Old Opera     no     photo        image/jpeg, Vary: Accept
+#     :          no     synthetic    image/png,  Vary: Accept +
+#     :         webp    photo        image/webp, Vary: Accept, Lossy
+#     :         webp    synthetic    image/png,  Cache-Control: private +
+#  Chrome or     no     photo        image/jpeg, Vary: Accept
+# Firefox or     no     synthetic    image/png,  Vary: Accept
+#  New Opera    webp    photo        image/webp, Vary: Accept, Lossy
+#     :         webp    synthetic    image/webp, Cache-Control: private +
+#                                    Lossless webp image returned
+# TODO(jmaessen): * cases currently send Vary: Accept.  Fix (in progress).
+# + has been rejected for now in favor of image/png, Vary: Accept.
+# TODO(jmaessen): eliminate Vary: Accept headers from synthetic images that
+# are never going to be considered for webp conversion.  This may prove
+# irrelevant if we instead decide to support Lossless via Vary: Accept and
+# abandon old Opera versions.
+function test_ipro_for_browser_webp() {
+  IN_UA_PRETTY="$1"; shift
+  IN_UA="$1"; shift
+  IN_ACCEPT="$1"; shift
+  IMAGE_TYPE="$1"; shift
+  OUT_CONTENT_TYPE="$1"; shift
+  OUT_VARY="$1"; shift
+  OUT_CC="${1-}"; shift
+  WGET_ARGS="--save-headers \
+             ${IN_UA:+--user-agent $IN_UA} \
+             ${IN_ACCEPT:+--header=Accept:image/$IN_ACCEPT}"
+  # Remaining args are the expected headers (Name:Value), photo, or synthetic.
+  if [ "$IMAGE_TYPE" = "photo" ]; then
+    URL="http://ipro-for-browser.example.com/images/Puzzle.jpg"
+  else
+    URL="http://ipro-for-browser.example.com/images/Cuppa.png"
+  fi
+  TEST_ID="In-place optimize for "
+  TEST_ID+="User-Agent:${IN_UA_PRETTY:-${IN_UA:-None}},"
+  if [ -z "$IN_ACCEPT" ]; then
+    TEST_ID+=" no accept, "
+  else
+    TEST_ID+=" Accept:$IN_ACCEPT, "
+  fi
+  TEST_ID+=" $IMAGE_TYPE.  Expect image/${IMAGE_TYPE}, "
+  if [ -z "$OUT_VARY" ]; then
+    TEST_ID+=" no vary, "
+  else
+    TEST_ID+=" Vary:${OUT_VARY}, "
+  fi
+  if [ -z "$OUT_CC" ]; then
+    TEST_ID+=" cacheable."
+  else
+    TEST_ID+=" Cache-Control:${OUT_CC}."
+  fi
+  start_test $TEST_ID
+  http_proxy=$SECONDARY_HOSTNAME \
+    fetch_until -save $URL 'grep -c W/\"PSA-aj-' 1
+  check_from "$(extract_headers $FETCH_UNTIL_OUTFILE)" \
+    fgrep -q "Content-Type: image/$OUT_CONTENT_TYPE"
+  if [ -z "$OUT_VARY" ]; then
+    check_not_from "$(extract_headers $FETCH_UNTIL_OUTFILE)" \
+      fgrep -q "Vary:"
+  else
+    check_from "$(extract_headers $FETCH_UNTIL_OUTFILE)" \
+      fgrep -q "Vary: $OUT_VARY"
+  fi
+  check_from "$(extract_headers $FETCH_UNTIL_OUTFILE)" \
+    fgrep -q "Cache-Control: ${OUT_CC:-max-age=}"
+  # TODO: check file type of webp.  Irrelevant for now.
+}
+
+##############################################################################
+# Test with testing-only user agent strings.
+#                          UA           Accept Type  Out  Vary     CC
+test_ipro_for_browser_webp "None" ""    ""     photo jpeg "Accept"
+test_ipro_for_browser_webp "" "webp"    ""     photo jpeg "Accept"
+test_ipro_for_browser_webp "" "webp-la" ""     photo jpeg "Accept"
+test_ipro_for_browser_webp "None" ""    "webp" photo webp "Accept"
+test_ipro_for_browser_webp "" "webp"    "webp" photo webp "Accept"
+test_ipro_for_browser_webp "" "webp-la" "webp" photo webp "Accept"
+test_ipro_for_browser_webp "None" ""    ""     synth png  "Accept"
+test_ipro_for_browser_webp "" "webp"    ""     synth png  "Accept"
+test_ipro_for_browser_webp "" "webp-la" ""     synth png  "Accept"
+test_ipro_for_browser_webp "None" ""    "webp" synth png  "Accept"
+test_ipro_for_browser_webp "" "webp"    "webp" synth png  "Accept"
+test_ipro_for_browser_webp "" "webp-la" "webp" synth png  "Accept"
+##############################################################################
+
+# Wordy UAs need to be stored in the WGETRC file to avoid death by quoting.
+OLD_WGETRC=$WGETRC
+WGETRC=$TEMPDIR/wgetrc-ua
+export WGETRC
+
+# IE 11 does not cache Vary: Accept.  For now we send it nonetheless.  See
+# TODO above.
+IE11_UA="Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko"
+echo "user_agent = $IE11_UA" > $WGETRC
+#                            (no accept) Type  Out  Vary
+test_ipro_for_browser_webp "IE 11" "" "" photo jpeg "Accept"
+test_ipro_for_browser_webp "IE 11" "" "" synth png  "Accept"
+
+# Older Opera did not support webp.
+OPERA_UA="Opera/9.80 (Windows NT 5.2; U; en) Presto/2.7.62 Version/11.01"
+echo "user_agent = $OPERA_UA" > $WGETRC
+#                                (no accept) Type  Out  Vary
+test_ipro_for_browser_webp "Old Opera" "" "" photo jpeg "Accept"
+test_ipro_for_browser_webp "Old Opera" "" "" synth png  "Accept"
+# Slightly newer opera supports only lossy webp, sends header.
+OPERA_UA="Opera/9.80 (Windows NT 6.0; U; en) Presto/2.8.99 Version/11.10"
+echo "user_agent = $OPERA_UA" > $WGETRC
+#                                           Accept Type  Out  Vary
+test_ipro_for_browser_webp "Newer Opera" "" "webp" photo webp "Accept"
+test_ipro_for_browser_webp "Newer Opera" "" "webp" synth png  "Accept"
+
+function test_decent_browsers() {
+  echo "user_agent = $2" > $WGETRC
+  #                          UA      Accept Type      Out  Vary
+  test_ipro_for_browser_webp "$1" "" ""     photo     jpeg "Accept"
+  test_ipro_for_browser_webp "$1" "" ""     synthetic  png "Accept"
+  test_ipro_for_browser_webp "$1" "" "webp" photo     webp "Accept"
+  test_ipro_for_browser_webp "$1" "" "webp" synthetic  png "Accept"
+}
+CHROME_UA="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 "
+CHROME_UA+="(KHTML, like Gecko) Chrome/32.0.1700.102 Safari/537.36"
+test_decent_browsers "Chrome" "$CHROME_UA"
+FIREFOX_UA="Mozilla/5.0 (X11; U; Linux x86_64; zh-CN; rv:1.9.2.10) "
+FIREFOX_UA+="Gecko/20100922 Ubuntu/10.10 (maverick) Firefox/3.6.10"
+test_decent_browsers "Firefox" "$FIREFOX_UA"
+test_decent_browsers "New Opera" \
+  "Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14"
+
+WGETRC=$OLD_WGETRC
+WGET_ARGS=""
+
 JS_URL="$HOSTNAME/ngx_pagespeed_static/js_defer.$HASH.js"
 JS_HEADERS=$($WGET -O /dev/null -q -S --header='Accept-Encoding: gzip' \
   $JS_URL 2>&1)
@@ -2109,6 +2244,38 @@ check_stat $STATS.2 $STATS.3 ipro_not_rewritable 1
 check_stat $STATS.2 $STATS.3 ipro_recorder_resources 0
 check_stat $STATS.2 $STATS.3 image_rewrites 0
 check_stat $STATS.2 $STATS.3 image_ongoing_rewrites 0
+
+# Check that IPRO served resources that don't specify a cache control
+# value are given the TTL specified by the ImplicitCacheTtlMs directive.
+start_test "IPRO respects ImplicitCacheTtlMs."
+HTML_URL=$IPRO_ROOT/no-cache-control-header/ipro.html
+RESOURCE_URL=$IPRO_ROOT/no-cache-control-header/test_image_dont_reuse.png
+RESOURCE_HEADERS=$OUTDIR/resource_headers
+OUTFILE=$OUTDIR/ipro_resource_output
+
+# Fetch the HTML to initiate rewriting and caching of the image.
+http_proxy=$SECONDARY_HOSTNAME check $WGET_DUMP $HTML_URL -O $OUTFILE
+
+# First IPRO resource request after a short wait: it will have the full TTL.
+sleep 2
+http_proxy=$SECONDARY_HOSTNAME check $WGET_DUMP $RESOURCE_URL -O $OUTFILE
+RESOURCE_MAX_AGE=$( \
+  extract_headers $OUTFILE | \
+  grep 'Cache-Control:' | tr -d '\r' | \
+  sed -e 's/^ *Cache-Control: *//' | sed -e 's/^.*max-age=\([0-9]*\).*$/\1/')
+check test -n "$RESOURCE_MAX_AGE"
+check test $RESOURCE_MAX_AGE -eq 333
+
+# Second IPRO resource request after a short wait: the TTL will be reduced.
+sleep 2
+http_proxy=$SECONDARY_HOSTNAME check $WGET_DUMP $RESOURCE_URL -O $OUTFILE
+RESOURCE_MAX_AGE=$( \
+  extract_headers $OUTFILE | \
+  grep 'Cache-Control:' | tr -d '\r' | \
+  sed -e 's/^ *Cache-Control: *//' | sed -e 's/^.*max-age=\([0-9]*\).*$/\1/')
+check test -n "$RESOURCE_MAX_AGE"
+check test $RESOURCE_MAX_AGE -lt 333
+check test $RESOURCE_MAX_AGE -gt 300
 
 start_test IPRO-optimized resources should have fixed size, not chunked.
 URL="$EXAMPLE_ROOT/images/Puzzle.jpg"

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -525,6 +525,17 @@ http {
 
   server {
     listen @@SECONDARY_PORT@@;
+    server_name ipro-for-browser.example.com;
+    root "@@SERVER_ROOT@@/mod_pagespeed_example";
+    pagespeed EnableFilters rewrite_images,rewrite_css;
+    pagespeed EnableFilters convert_to_webp_lossless;
+    pagespeed EnableFilters in_place_optimize_for_browser;
+    pagespeed InPlaceResourceOptimization on;
+    pagespeed FileCachePath "@@FILE_CACHE@@_ipro_for_browser";
+  }
+
+  server {
+    listen @@SECONDARY_PORT@@;
     server_name respectvary.example.com;
     pagespeed FileCachePath "@@FILE_CACHE@@";
 
@@ -709,6 +720,11 @@ http {
 
     location /mod_pagespeed_test/ipro/nocache/test_image_dont_reuse.png {
       add_header Cache-Control no-cache;
+    }
+
+    location /mod_pagespeed_test/ipro/no-cache-control-header {
+      add_header Cache-Control "";
+      pagespeed ImplicitCacheTtlMs 333000;
     }
   }
 


### PR DESCRIPTION
The big change here is Vary: headers, which are no longer being stripped from the pagespeed response.  Take a look; it might be we want to be smart about merging these headers with the original request's Vary: headers.
