### PR TITLE
header-handling: Update/append headers so we remember deletions.

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -403,8 +403,26 @@ ngx_int_t copy_response_headers_to_ngx(
       continue;
     } else if (STR_EQ_LITERAL(name, "Transfer-Encoding")) {
       continue;
-    } else if (STR_EQ_LITERAL(name, "Server")) {
-      continue;
+    } else {
+      // Update or append response headers.
+      NgxListIterator it(&(r->headers_out.headers.part));
+      ngx_table_elt_t* header;
+      bool handled = false;
+
+      while ((header = it.Next()) != NULL) {
+        StringPiece sp(reinterpret_cast<char*>(header->key.data),
+                       static_cast<int>(header->key.len));
+        if (StringCaseEqual(sp, name_gs)) {
+          header->value.len = value.len;
+          header->value.data = value_s;
+          handled = true;
+          break;
+        }
+      }
+
+      if (handled) {
+        continue;
+      }
     }
 
     u_char* name_s = ngx_pstrdup(r->pool, &name);
@@ -1179,9 +1197,8 @@ ngx_int_t ps_base_fetch_handler(ngx_http_request_t* r) {
           header->hash = 0;
         }
       }
-    } else {
-      ngx_http_clean_header(r);
     }
+
     // collect response headers from pagespeed
     rc = ctx->base_fetch->CollectHeaders(&r->headers_out);
     if (rc == NGX_ERROR) {

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -2748,6 +2748,14 @@ start_test Base config has purging disabled.  Check error message syntax.
 OUT=$($WGET_DUMP "$HOSTNAME/pagespeed_admin/cache?purge=*")
 check_from "$OUT" fgrep -q "pagespeed EnableCachePurge on;"
 
+start_test deleted headers stay put
+WGET_ARGS=""
+URL="$SECONDARY_HOSTNAME/mod_pagespeed_example/"
+FETCH_CMD="$WGET_DUMP --header=Host:header-delete.example.com $URL"
+OUT=$($FETCH_CMD)
+check_not_from "$OUT" fgrep "X-PageSpeed"
+check_not_from "$OUT" fgrep "Server"
+
 if $USE_VALGRIND; then
     # It is possible that there are still ProxyFetches outstanding
     # at this point in time. Give them a few extra seconds to allow

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -809,6 +809,14 @@ http {
     pagespeed FileCachePath "@@FILE_CACHE@@";
   }
 
+  server { 
+    listen @@SECONDARY_PORT@@;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    server_name header-delete.example.com;
+    more_clear_headers 'Server';
+    more_clear_headers 'X-Page-Speed';
+  }
+
   server {
     listen @@SECONDARY_PORT@@;
     listen [::]:@@SECONDARY_PORT@@;


### PR DESCRIPTION
Instead of fully clearing the headers, switch to update/append, so
we don't loose information on headers that got deleted by modules
running before us.

Partly fixes https://github.com/pagespeed/ngx_pagespeed/issues/612
(fixes the html flow).
