### PR TITLE
trunk-tracking: update from r3852 to r3872

### DIFF
--- a/src/ngx_pagespeed.h
+++ b/src/ngx_pagespeed.h
@@ -117,6 +117,8 @@ ngx_int_t copy_response_headers_to_ngx(
     const ResponseHeaders& pagespeed_headers,
     PreserveCachingHeaders preserve_caching_headers);
 
+StringPiece ps_determine_host(ngx_http_request_t* r);
+
 }  // namespace net_instaweb
 
 #endif  // NGX_PAGESPEED_H_

--- a/src/ngx_server_context.cc
+++ b/src/ngx_server_context.cc
@@ -72,6 +72,7 @@ SystemRequestContext* NgxServerContext::NewRequestContext(
 
   return new SystemRequestContext(thread_system()->NewMutex(),
                                   timer(),
+                                  ps_determine_host(r),
                                   local_port,
                                   str_to_string_piece(local_ip));
 }

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1091,8 +1091,8 @@ cat "$SERVER_ROOT/mod_pagespeed_test/embed_config.html" | \
 # spelling it out to avoid test regolds when we add image filter IDs.
 WGET_ARGS="--save-headers"
 http_proxy=$SECONDARY_HOSTNAME fetch_until -save -recursive \
-    http://embed-config-html.example.com/embed-config.html \
-    'fgrep -c .pagespeed.' 3
+    http://embed-config-html.example.org/embed-config.html \
+    'grep -c \.pagespeed\.' 3
 
 # with the default rewriters in vhost embed-config-resources.example.com
 # the image will be >200k.  But by enabling resizing & compression 73
@@ -2158,7 +2158,7 @@ function test_ipro_for_browser_webp() {
       fgrep -q "Vary: $OUT_VARY"
   fi
   check_from "$(extract_headers $FETCH_UNTIL_OUTFILE)" \
-    fgrep -q "Cache-Control: ${OUT_CC:-max-age=}"
+    grep -q "Cache-Control: ${OUT_CC:-max-age=[0-9]*}$"
   # TODO: check file type of webp.  Irrelevant for now.
 }
 
@@ -2184,12 +2184,15 @@ OLD_WGETRC=$WGETRC
 WGETRC=$TEMPDIR/wgetrc-ua
 export WGETRC
 
-# IE 11 does not cache Vary: Accept.  For now we send it nonetheless.  See
-# TODO above.
-IE11_UA="Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko"
+# IE 9 and later must re-validate Vary: Accept.  We should send CC: private.
+IE9_UA="Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))"
+IE11_UA="Mozilla/5.0 (Windows NT 6.1; WOW64; ***********; rv:11.0) like Gecko"
+echo "user_agent = $IE9_UA" > $WGETRC
+#                           (no accept)  Type  Out  Vary CC
+test_ipro_for_browser_webp "IE 9"  "" "" photo jpeg ""   "max-age=[0-9]*,private"
+test_ipro_for_browser_webp "IE 9"  "" "" synth png
 echo "user_agent = $IE11_UA" > $WGETRC
-#                            (no accept) Type  Out  Vary
-test_ipro_for_browser_webp "IE 11" "" "" photo jpeg "Accept"
+test_ipro_for_browser_webp "IE 11" "" "" photo jpeg ""   "max-age=[0-9]*,private"
 test_ipro_for_browser_webp "IE 11" "" "" synth png
 
 # Older Opera did not support webp.
@@ -2387,6 +2390,12 @@ check test -n "$RESOURCE_MAX_AGE"
 check test $RESOURCE_MAX_AGE -lt 333
 check test $RESOURCE_MAX_AGE -gt 300
 
+# TODO(jmaessen, jefftk): Port proxying tests, which rely on pointing a
+# MapProxyDomain construct at a static server.  Perhaps localhost:8050 will
+# serve, but the tests need to use different urls then.  For mod_pagespeed these
+# tests immediately precede "IPRO-optimized resources should have fixed size,
+# not chunked." in system_test.sh.
+
 start_test IPRO-optimized resources should have fixed size, not chunked.
 URL="$EXAMPLE_ROOT/images/Puzzle.jpg"
 URL+="?PageSpeedJpegRecompressionQuality=75"
@@ -2397,6 +2406,16 @@ CONTENT_LENGTH=$(extract_headers $FETCH_UNTIL_OUTFILE | \
 check [ "$CONTENT_LENGTH" -lt 90000 ];
 check_not_from "$(extract_headers $FETCH_UNTIL_OUTFILE)" \
     fgrep -q 'Transfer-Encoding: chunked'
+
+start_test IPRO 304 with etags
+# Reuses $URL and $FETCH_UNTIL_OUTFILE from previous test.
+check_from "$(extract_headers $FETCH_UNTIL_OUTFILE)" fgrep -q 'ETag:'
+ETAG=$(extract_headers $FETCH_UNTIL_OUTFILE | awk '/ETag:/ {print $2}')
+echo $WGET_DUMP --header "If-None-Match: $ETAG" $URL
+OUTFILE=$OUTDIR/etags
+# Note: -o gets debug info which is the only place that 304 message is sent.
+$WGET -o $OUTFILE -O /dev/null --header "If-None-Match: $ETAG" $URL
+check fgrep -q "awaiting response... 304" $OUTFILE
 
 start_test PageSpeed resources should have a content length.
 URL="$EXAMPLE_ROOT/styles/W.rewrite_css_images.css.pagespeed.cf.Hash.css"

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -494,7 +494,7 @@ http {
   # Note that we test with two distinct caches.
   server {
     listen @@SECONDARY_PORT@@;
-    server_name embed-config-html.example.com;
+    server_name embed-config-html.example.org;
     pagespeed FileCachePath "@@FILE_CACHE@@";
 
     root "@@SERVER_ROOT@@/mod_pagespeed_test";
@@ -503,6 +503,9 @@ http {
     pagespeed JpegRecompressionQuality 73;
     pagespeed DisableFilters inline_css,extend_cache,inline_javascript;
     pagespeed Domain embed-config-resources.example.com;
+
+    # Share a cache keyspace with embed-config-resources.example.com.
+    pagespeed CacheFragment "embed-config";
 
     pagespeed LoadFromFile "http://embed-config-resources.example.com/"
       "@@SERVER_ROOT@@/mod_pagespeed_example/";
@@ -519,7 +522,10 @@ http {
 
     # Note that we do not set the jpeg quality here, but take
     # it from image URL query parameters that we synthesize in
-    # from embed-config-html.example.com.
+    # from embed-config-html.example.org.
+
+    # Share a cache keyspace with embed-config-html.example.org.
+    pagespeed CacheFragment "embed-config";
 
     pagespeed LoadFromFile "http://embed-config-resources.example.com/"
       "@@SERVER_ROOT@@/mod_pagespeed_example/";
@@ -587,6 +593,7 @@ http {
     pagespeed MapRewriteDomain cdn.example.com origin.example.com;
     pagespeed RewriteLevel PassThrough;
     pagespeed EnableFilters rewrite_css,rewrite_images;
+    pagespeed CacheFragment "example";
   }
   server {
     # Sets up a logical origin for CDNs to fetch content from, on
@@ -599,6 +606,7 @@ http {
     pagespeed MapRewriteDomain cdn.example.com origin.example.com;
     pagespeed RewriteLevel PassThrough;
     pagespeed EnableFilters rewrite_css,rewrite_images;
+    pagespeed CacheFragment "example";
   }
   server {
     # Sets up a logical cdn, which is where we tell browsers to fetch resources


### PR DESCRIPTION
OK, this looks more like it.  Note that major changes are under way to console and static content handling and are expected to land this week (courtesy Josh).  This pull request contains a shim for the first part of this work, but there's going to need to be some concerted work transforming the nginx side to use a real request object in all cases.
