### PR TITLE
Console response headers: quick fix to let PSOL determine them

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -2357,9 +2357,8 @@ ngx_int_t ps_simple_handler(ngx_http_request_t* r,
           cfg_s->server_context->NewRequestContext(r));
       NgxPagespeedConsoleAsyncFetch fetch(request_context, &writer);
       server_context->ConsoleHandler(*server_context->config(), &fetch);
-      status = static_cast<HttpStatus::Code>(
-          fetch.response_headers()->status_code());
-      break;
+      send_out_headers_and_body(r, *fetch.response_headers(), output);
+      return NGX_OK;
     }
     case RequestRouting::kMessages: {
       GoogleString log;


### PR DESCRIPTION
Quick hack to make sure PSOL is the one that determines the emitted response headers for the `ConsoleHandler` when the `NgxPagespeedConsoleAsyncFetch` shim is used.

I think it would be good to have some test coverage here as well.
