### PR TITLE
downstream-caching: Fix pagespeed resource response headers

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -2546,6 +2546,14 @@ check_from "$OUT" egrep -q $'^Content-Length: ([0-9])*\r$'
 check_not_from "$OUT" egrep -iq $'^Transfer-Encoding: chunked\r$'
 check_not_from "$OUT" egrep -iq $'^Connection: close\r$'
 
+start_test Downstream cache integration caching headers.
+URL="http://downstreamcacheresource.example.com/mod_pagespeed_example/images/"
+URL+="xCuppa.png.pagespeed.ic.0.png"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+check_from "$OUT" egrep -iq $'^Cache-Control: .*\r$'
+check_from "$OUT" egrep -iq $'^Expires: .*\r$'
+check_from "$OUT" egrep -iq $'^Last-Modified: .*\r$'
+
 # Test handling of large HTML files. We first test with a cold cache, and verify
 # that we bail out of parsing and insert a script redirecting to
 # ?PageSpeed=off. This should also insert an entry into the property cache so

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -329,6 +329,15 @@ http {
 
   server {
     listen @@SECONDARY_PORT@@;
+    server_name downstreamcacheresource.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    pagespeed RewriteLevel PassThrough;
+    pagespeed EnableFilters rewrite_images;
+    pagespeed DownstreamCachePurgeLocationPrefix "http://localhost:@@SECONDARY_PORT@@/purge";
+  }
+
+  server {
+    listen @@SECONDARY_PORT@@;
     server_name renderedimagebeacon.example.com;
     pagespeed FileCachePath "@@FILE_CACHE@@";
 


### PR DESCRIPTION
- Make `kPreserveOnlyCacheControl` do what it says on the tin
- Serve pagespeed resources with the response headers computed
  by PSOL regardless of whether downstream caching is configured.

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/652
