### PR TITLE
native-fetcher: fix CHECK failure on DNS timeout

### DIFF
--- a/src/ngx_fetch.h
+++ b/src/ngx_fetch.h
@@ -83,6 +83,12 @@ class NgxFetch : public PoolElement<NgxFetch> {
   void set_timeout_event(ngx_event_t* x) {
     timeout_event_ = x;
   }
+  void release_resolver() {
+    if (resolver_ctx_ != NULL && resolver_ctx_ != NGX_NO_RESOLVER) {
+      ngx_resolve_name_done(resolver_ctx_);
+      resolver_ctx_ = NULL;
+    }
+  }
 
  private:
   response_handler_pt response_handler;


### PR DESCRIPTION
Make sure we clear the timeout event associated with resolving
a hostname in `CallbackDone()`, which would otherwise end up
calling `CallbackDone()` a second time upon firing.

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/625
