### PR TITLE
clean up the conf file overrides to turn off proactive resource

### DIFF
--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -34,11 +34,6 @@ http {
   pagespeed AdminPath /pagespeed_admin;
   pagespeed GlobalAdminPath /pagespeed_global_admin;
 
-  # TODO(jefftk): this option currently breaks IPRO after cache flushing.  This
-  # was turned on by default with PSOL r3966 and needs to be fixed there.
-  pagespeed CompressMetadataCache off;
-  pagespeed ProactiveResourceFreshening off;
-
   root "@@SERVER_ROOT@@";
 
   # Block 5a: Decide on Cache-Control header value to use for outgoing


### PR DESCRIPTION
fetching and compressed cache.  the compressed cache was ok but
proactive resource fetching consistently fails system tests in nginx
