### PR TITLE
Allow admin paths to be set at server scope.

### DIFF
--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -102,20 +102,20 @@ void NgxRewriteOptions::AddProperties() {
   // Nginx-specific options.
   add_ngx_option(
       "", &NgxRewriteOptions::statistics_path_, "nsp", kStatisticsPath,
-      kProcessScope, "Set the statistics path. Ex: /ngx_pagespeed_statistics");
+      kServerScope, "Set the statistics path. Ex: /ngx_pagespeed_statistics");
   add_ngx_option(
       "", &NgxRewriteOptions::global_statistics_path_, "ngsp",
       kGlobalStatisticsPath, kProcessScope,
       "Set the global statistics path. Ex: /ngx_pagespeed_global_statistics");
   add_ngx_option(
-      "", &NgxRewriteOptions::console_path_, "ncp", kConsolePath, kProcessScope,
+      "", &NgxRewriteOptions::console_path_, "ncp", kConsolePath, kServerScope,
       "Set the console path. Ex: /pagespeed_console");
   add_ngx_option(
       "", &NgxRewriteOptions::messages_path_, "nmp", kMessagesPath,
-      kProcessScope, "Set the messages path.  Ex: /ngx_pagespeed_message");
+      kServerScope, "Set the messages path.  Ex: /ngx_pagespeed_message");
   add_ngx_option(
       "", &NgxRewriteOptions::admin_path_, "nap", kAdminPath,
-      kProcessScope, "Set the admin path.  Ex: /pagespeed_admin");
+      kServerScope, "Set the admin path.  Ex: /pagespeed_admin");
   add_ngx_option(
       "", &NgxRewriteOptions::global_admin_path_, "ngap", kGlobalAdminPath,
       kProcessScope, "Set the global admin path.  Ex: /pagespeed_global_admin");

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -522,6 +522,60 @@ if [ "$HOSTNAME" = "localhost:$PRIMARY_PORT" ] ; then
   AUTH=""
 fi
 
+start_test "Custom statistics paths in server block"
+
+# Served on normal paths by default.
+URL="inherit-paths.example.com/ngx_pagespeed_statistics"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+check_from "$OUT" grep cache_time_us
+
+URL="inherit-paths.example.com/ngx_pagespeed_message"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+check_from "$OUT" grep Info
+
+URL="inherit-paths.example.com/pagespeed_console"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+check_from "$OUT" grep console_div
+
+URL="inherit-paths.example.com/pagespeed_admin/"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+check_from "$OUT" grep Admin
+
+# Not served on normal paths when overriden.
+URL="custom-paths.example.com/ngx_pagespeed_statistics"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+check_not_from "$OUT" grep cache_time_us
+
+URL="custom-paths.example.com/ngx_pagespeed_message"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+check_not_from "$OUT" grep Info
+
+URL="custom-paths.example.com/pagespeed_console"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+check_not_from "$OUT" grep console_div
+
+URL="custom-paths.example.com/pagespeed_admin/"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+check_not_from "$OUT" grep Admin
+
+# Served on custom paths when overriden
+URL="custom-paths.example.com/custom_pagespeed_statistics"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+check_from "$OUT" grep cache_time_us
+
+URL="custom-paths.example.com/custom_pagespeed_message"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+check_from "$OUT" grep Info
+
+URL="custom-paths.example.com/custom_pagespeed_console"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+check_from "$OUT" grep console_div
+
+URL="custom-paths.example.com/custom_pagespeed_admin/"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+check_from "$OUT" grep Admin
+
+
 WGET_ARGS=""
 function gunzip_grep_0ff() {
   gunzip - | fgrep -q "color:#00f"

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -725,6 +725,23 @@ http {
 
   server {
     listen @@SECONDARY_PORT@@;
+    server_name custom-paths.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+
+    pagespeed StatisticsPath /custom_pagespeed_statistics;
+    pagespeed ConsolePath /custom_pagespeed_console;
+    pagespeed MessagesPath /custom_pagespeed_message;
+    pagespeed AdminPath /custom_pagespeed_admin;
+  }
+
+  server {
+    listen @@SECONDARY_PORT@@;
+    server_name inherit-paths.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+  }
+
+  server {
+    listen @@SECONDARY_PORT@@;
     server_name notransform.example.com;
     pagespeed FileCachePath "@@FILE_CACHE@@";
 


### PR DESCRIPTION
Allow you to set `MessagesPath`, `StatisticsPath`, `AdminPath`, or `ConsolePath`  in a `server {}` block.
