### PR TITLE
content-length: when we don't preserve headers, clear the CL header

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -1084,6 +1084,7 @@ ngx_int_t ps_base_fetch_handler(ngx_http_request_t* r) {
           header->hash = 0;
         }
       }
+      ngx_http_clear_content_length(r);
     } else {
       ngx_http_clean_header(r);
     }


### PR DESCRIPTION
I haven't been able to reproduce a problem with this, looking at the code it seems to me that we do need to do this.
