### PR TITLE
Color messages in the message_history page. Add system test for this change.

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -2443,7 +2443,7 @@ ngx_int_t ps_simple_handler(ngx_http_request_t* r,
                      "Please check if it's enabled in pagespeed.conf.\n",
                      message_handler);
       } else {
-        HtmlKeywords::WritePre(log, &writer, message_handler);
+        HtmlKeywords::WritePre(log, "", &writer, message_handler);
       }
       break;
     }

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -2633,6 +2633,18 @@ OUTFILE=$OUTDIR/etags
 $WGET -o $OUTFILE -O /dev/null --header "If-None-Match: $ETAG" $URL
 check fgrep -q "awaiting response... 304" $OUTFILE
 
+# Test if the warning messages are colored in message_history page.
+# We color the messages in message_history page to make it clearer to read.
+# Red for Error messages. Blue for Warning messages.
+# Orange for Fatal messages. Black by default.
+# Won't test Error messages and Fatal messages in this test.
+# TODO(xqyin): test all the types of messages in future unit test.
+start_test Messages are colored in message_history
+INJECT=$($CURL --silent $HOSTNAME/?PageSpeed=Warning_trigger)
+OUT=$($WGET -q -O - $HOSTNAME/pagespeed_admin/message_history | \
+  grep Warning_trigger)
+check_from "$OUT" fgrep -q "color:blue;"
+
 start_test PageSpeed resources should have a content length.
 URL="$EXAMPLE_ROOT/styles/W.rewrite_css_images.css.pagespeed.cf.Hash.css"
 OUT=$($WGET_DUMP --save-headers $URL)


### PR DESCRIPTION
Modify HtmlKeywords::WritePre function to take a new argument. The new argument adds a style attribute to the pre-tag. Here use the empty string to indicate that style attribute won't be used. 

To add a style attribute is to color messages in message_history page. That part of codes can be viewed in net/instaweb/system/system_server_context.cc.

The corresponding system test is added. A warning message is injected before the test to make sure that there is at least one warning message in the message_history page.
