### PR TITLE
headers: content length is now tested in common code

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -2645,13 +2645,6 @@ OUT=$($WGET -q -O - $HOSTNAME/pagespeed_admin/message_history | \
   grep Warning_trigger)
 check_from "$OUT" fgrep -q "color:blue;"
 
-start_test PageSpeed resources should have a content length.
-URL="$EXAMPLE_ROOT/styles/W.rewrite_css_images.css.pagespeed.cf.Hash.css"
-OUT=$($WGET_DUMP --save-headers $URL)
-check_from "$OUT" egrep -q $'^Content-Length: ([0-9])*\r$'
-check_not_from "$OUT" egrep -iq $'^Transfer-Encoding: chunked\r$'
-check_not_from "$OUT" egrep -iq $'^Connection: close\r$'
-
 start_test Downstream cache integration caching headers.
 URL="http://downstreamcacheresource.example.com/mod_pagespeed_example/images/"
 URL+="xCuppa.png.pagespeed.ic.0.png"


### PR DESCRIPTION
The test from #713 was going to replace this code, but that's actually going into `automatic/system_test.sh`.  Remove this now-redundant test.
