### PR TITLE
ipro-lff: Prevent handing out 200/OK when we can't rewrite in place

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -1028,7 +1028,6 @@ ngx_int_t ps_decline_request(ngx_http_request_t* r) {
   ctx->fetch_done = false;
   ctx->write_pending = false;
 
-  ps_release_base_fetch(ctx);
   ps_set_buffered(r, false);
 
   r->count++;


### PR DESCRIPTION
PSOL change for in_place_rewrite_context.cc
- Reorder setting the status code so we actually change the
  ResponseHeaders that we are using to serve
- Prevent non-error http status codes from being served up.

As noted by @jeffkaufman, to prevent a potential lifetime issue with
ResponseHeaders, remove the call to ps_release_base_fetch() in
ps_decline_request().

This fixes the issue where a .woff file served via LoadFromFile and IPRO
would give a 0 bytes response, but blacklisting in LoadFromFile is probably
better. 

PSOL patch:

``` diff
--- ../rewriter/in_place_rewrite_context.cc (revision 4020)
+++ ../rewriter/in_place_rewrite_context.cc (working copy)
@@ -127,9 +127,20 @@
       // to us.
       streaming_ = false;
       set_request_headers(NULL);
+      // If we cannot rewrite in-place, we should not serve a 200/OK.
+      // Serve kNotFound instead to fall back to the server's native
+      // method of serving the url and indicate we don't want it recorded
+      // either.
+      // TODO(oschaaf): When the resource is loaded via LoadFromFile,
+      // this code gets repeatedly hit for the same url. That might
+      // become a drag when the file in question is very large and popular.
+      // Marking urls that end up in this flow as not cachable in the http cache
+      // at this point had no effect (for the LoadFromFile flow at least).
+      if (!response_headers()->IsErrorStatus()) {
+   response_headers()->set_status_code(HttpStatus::kNotFound);
+      }
       set_response_headers(NULL);
       set_extra_response_headers(NULL);
-      response_headers()->set_status_code(HttpStatus::kNotFound);
       SharedAsyncFetch::HandleDone(false);
     }
   }
```
