### PR TITLE
Change the options passed into AdminSite to be SystemRewriteOptions

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -1866,12 +1866,14 @@ ngx_int_t ps_resource_handler(ngx_http_request_t* r,
           ctx->base_fetch);
     } else if (response_category == RequestRouting::kAdmin ||
                response_category == RequestRouting::kGlobalAdmin) {
+      RewriteOptions* system_options =
+          (custom_options == NULL) ? cfg_s->server_context->config() :
+          custom_options.get();
       cfg_s->server_context->AdminPage(
           response_category == RequestRouting::kGlobalAdmin,
           url,
           query_params,
-          custom_options == NULL ? cfg_s->server_context->config()
-                                 : custom_options.get(),
+          dynamic_cast<SystemRewriteOptions*>(system_options),
           ctx->base_fetch);
     } else if (response_category == RequestRouting::kCachePurge) {
       AdminSite* admin_site = cfg_s->server_context->admin_site();


### PR DESCRIPTION
Several Handler methods like ConsoleHandler() and MessageHistoryHandler() in AdminSite need to take per request options (we are passing global options to it currently) so that the JS code on the page won't be optimized when the debug filter is turned on. We change the type of options in AdminSite to be SystemRewriteOptions to take URL query parameters. So here in Nginx we have to pass a SystemRewriteOptions to AdminSite::AdminPage method.
