### PR TITLE
script-variables: Support LoadFromFileXXX

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -576,7 +576,20 @@ char* ps_init_dir(const StringPiece& directive,
   return NULL;
 }
 
-#define NGX_PAGESPEED_MAX_ARGS 10
+// We support interpretation of nginx variables in some configuration settings, but
+// we also need to support literal dollar signs in those same settings.  Nginx has no good
+// solution for this, so we define $dollar to expand to '$', which lets people include
+// literal dollar signs if they need them.
+ngx_int_t ps_dollar(
+    ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data) {
+  v->valid = 1;
+  v->no_cacheable = 0;
+  v->not_found = 0;
+  v->data = reinterpret_cast<u_char*>(const_cast<char*>("$"));
+  v->len = 1;
+  return NGX_OK;
+}
+
 char* ps_configure(ngx_conf_t* cf,
                    NgxRewriteOptions** options,
                    MessageHandler* handler,
@@ -637,8 +650,26 @@ char* ps_configure(ngx_conf_t* cf,
     *options = new NgxRewriteOptions(
         cfg_m->driver_factory->thread_system());
   }
+
+  bool process_script_variables = dynamic_cast<NgxRewriteDriverFactory*>(
+      cfg_m->driver_factory)->process_script_variables();
+
+  if (process_script_variables) {
+    // To be able to use '$', we map '$ps_dollar' to '$' via a script variable.
+    ngx_str_t name = ngx_string("ps_dollar");
+    ngx_http_variable_t* var = ngx_http_add_variable(
+        cf, &name, NGX_HTTP_VAR_CHANGEABLE);
+
+    if (var == NULL) {
+      return const_cast<char*>(
+          "Failed to add global configuration variable for '$ps_dollar'");
+    }
+    var->get_handler = ps_dollar;
+  }
+
   const char* status = (*options)->ParseAndSetOptions(
-      args, n_args, cf->pool, handler, cfg_m->driver_factory, option_scope);
+      args, n_args, cf->pool, handler, cfg_m->driver_factory, option_scope, cf,
+      process_script_variables);
 
   // nginx expects us to return a string literal but doesn't mark it const.
   return const_cast<char*>(status);
@@ -805,6 +836,16 @@ void ps_merge_options(NgxRewriteOptions* parent_options,
     NgxRewriteOptions* child_specific_options = *child_options;
     *child_options = parent_options->Clone();
     (*child_options)->Merge(*child_specific_options);
+
+    if (child_specific_options->clear_inherited_scripts()) {
+      // We don't want to inherit any inherited script lines from the parent
+      // options here, so we just stick to the child specific ones.
+      child_specific_options->CopyScriptLinesTo(*child_options);
+    } else {
+      // We append the child specific script lines to the parent's script lines
+      // so we preserve the order in which they will be executed at request time
+      child_specific_options->AppendScriptLinesTo(*child_options);
+    }
     delete child_specific_options;
   }
 }
@@ -846,6 +887,9 @@ char* ps_merge_srv_conf(ngx_conf_t* cf, void* parent, void* child) {
   // let it do that, then merge in options we got from the config file.
   // Once we do that we're done with cfg_s->options.
   cfg_s->server_context->global_options()->Merge(*cfg_s->options);
+  NgxRewriteOptions* ngx_options = dynamic_cast<NgxRewriteOptions*>(
+      cfg_s->server_context->global_options());
+  cfg_s->options->CopyScriptLinesTo(ngx_options);
   delete cfg_s->options;
   cfg_s->options = NULL;
 
@@ -1403,9 +1447,13 @@ bool ps_determine_options(ngx_http_request_t* r,
 
   // Because the caller takes ownership of any options we return, the only
   // situation in which we can avoid allocating a new RewriteOptions is if the
-  // global options are ok as are.
+  // global options are ok as they are and we don't have script variables we
+  // need to evaluate at this point.
+  NgxRewriteOptions* ngx_global_options =
+      dynamic_cast<NgxRewriteOptions*>(global_options);
   if (!have_request_options && directory_options == NULL &&
-      !global_options->running_experiment()) {
+      !global_options->running_experiment() &&
+      ngx_global_options->script_lines().size() == 0) {
     return true;
   }
 
@@ -1414,6 +1462,18 @@ bool ps_determine_options(ngx_http_request_t* r,
     *options = directory_options->Clone();
   } else {
     *options = global_options->Clone();
+  }
+
+  NgxRewriteDriverFactory* ngx_factory = dynamic_cast<NgxRewriteDriverFactory*>(
+    cfg_s->server_context->factory());
+  NgxRewriteOptions* ngx_options = dynamic_cast<NgxRewriteOptions*>(*options);
+
+  // ExecuteScriptVariables() sets 'pagespeed off' on ngx_options when execution
+  // fails and then returns false. When that happens we return, as we don't want
+  // to allow enabling pagespeed by request and execute without the intended
+  // configuration.
+  if (!ngx_options->ExecuteScriptVariables(r, cfg_s->handler, ngx_factory)) {
+    return false;
   }
 
   // Modify our options in response to request options if specified.

--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -80,7 +80,9 @@ NgxRewriteDriverFactory::NgxRewriteDriverFactory(
       use_native_fetcher_(false),
       ngx_shared_circular_buffer_(NULL),
       hostname_(hostname.as_string()),
-      port_(port) {
+      port_(port),
+      process_script_variables_(false),
+      process_script_variables_set_(false) {
   InitializeDefaultOptions();
   default_options()->set_beacon_url("/ngx_pagespeed_beacon");
   SystemRewriteOptions* system_options = dynamic_cast<SystemRewriteOptions*>(

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -105,12 +105,24 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   void set_use_native_fetcher(bool x) {
     use_native_fetcher_ = x;
   }
+  bool process_script_variables() {
+    return process_script_variables_;
+  }
 
   void LoggingInit(ngx_log_t* log);
 
   virtual void ShutDownMessageHandlers();
 
   virtual void SetCircularBuffer(SharedCircularBuffer* buffer);
+
+  bool SetProcessScriptVariables(bool process_script_variables) {
+    if (!process_script_variables_set_) {
+      process_script_variables_ = process_script_variables;
+      process_script_variables_set_ = true;
+      return true;
+    }
+    return false;
+  }
 
  private:
   Timer* timer_;
@@ -137,6 +149,8 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
 
   GoogleString hostname_;
   int port_;
+  bool process_script_variables_;
+  bool process_script_variables_set_;
 
   DISALLOW_COPY_AND_ASSIGN(NgxRewriteDriverFactory);
 };

--- a/src/ngx_rewrite_options.h
+++ b/src/ngx_rewrite_options.h
@@ -27,12 +27,80 @@ extern "C" {
   #include <ngx_http.h>
 }
 
+#include <vector>
+
+#include "net/instaweb/util/public/message_handler.h"
+#include "net/instaweb/util/public/ref_counted_ptr.h"
+#include "net/instaweb/util/public/stl_util.h"          // for STLDeleteElements
 #include "net/instaweb/rewriter/public/rewrite_options.h"
 #include "net/instaweb/system/public/system_rewrite_options.h"
+
+#define NGX_PAGESPEED_MAX_ARGS 10
 
 namespace net_instaweb {
 
 class NgxRewriteDriverFactory;
+
+class ScriptArgIndex {
+ public:
+  explicit ScriptArgIndex(ngx_http_script_compile_t* script, int index)
+    : script_(script), index_(index) {
+      CHECK(script != NULL);
+      CHECK(index > 0 && index < NGX_PAGESPEED_MAX_ARGS);
+  }
+
+  virtual ~ScriptArgIndex() {}
+
+  ngx_http_script_compile_t* script() { return script_; }
+  int index() { return index_; }
+
+ private:
+  // Not owned.
+  ngx_http_script_compile_t* script_;
+  int index_;
+};
+
+// Refcounted, because the ScriptArgIndexes inside data_ can be shared between
+// different rewriteoptions.
+class ScriptLine : public RefCounted<ScriptLine> {
+ public:
+  explicit ScriptLine(StringPiece* args, int n_args,
+                      RewriteOptions::OptionScope scope)
+    : n_args_(n_args),
+      scope_(scope) {
+
+      for (int i = 0; i < n_args; i++) {
+        args_[i] = args[i];
+      }
+  }
+
+  virtual ~ScriptLine() {
+    STLDeleteElements(&data_);
+    data_.clear();
+  }
+
+  void AddScriptAndArgIndex(ngx_http_script_compile_t* script,
+                            int script_index) {
+    CHECK(script != NULL);
+    CHECK(script_index <  NGX_PAGESPEED_MAX_ARGS);
+    data_.push_back(new ScriptArgIndex(script, script_index));
+  }
+
+  int n_args() { return n_args_;}
+  StringPiece* args() { return args_;}
+  RewriteOptions::OptionScope scope() { return scope_; }
+  std::vector<ScriptArgIndex*>& data() {
+    return data_;
+  }
+
+ private:
+  StringPiece args_[NGX_PAGESPEED_MAX_ARGS];
+  int n_args_;
+  RewriteOptions::OptionScope scope_;
+  std::vector<ScriptArgIndex*> data_;
+
+  DISALLOW_COPY_AND_ASSIGN(ScriptLine);
+};
 
 class NgxRewriteOptions : public SystemRewriteOptions {
  public:
@@ -56,9 +124,19 @@ class NgxRewriteOptions : public SystemRewriteOptions {
   // on failure.
   //
   // pool is a memory pool for allocating error strings.
+  // cf is only required when compile_scripts is true
+  // when compile_scripts is true, the rewrite_options will be prepared
+  // for replacing any script $variables encountered in args. when false,
+  // script variables will be substituted using the prepared rewrite options.
   const char* ParseAndSetOptions(
       StringPiece* args, int n_args, ngx_pool_t* pool, MessageHandler* handler,
-      NgxRewriteDriverFactory* driver_factory, OptionScope scope);
+      NgxRewriteDriverFactory* driver_factory, OptionScope scope,
+      ngx_conf_t* cf, bool compile_scripts);
+  bool ExecuteScriptVariables(
+      ngx_http_request_t* r, MessageHandler* handler,
+      NgxRewriteDriverFactory* driver_factory);
+  void CopyScriptLinesTo(NgxRewriteOptions* destination) const;
+  void AppendScriptLinesTo(NgxRewriteOptions* destination) const;
 
   // Make an identical copy of these options and return it.
   virtual NgxRewriteOptions* Clone() const;
@@ -85,6 +163,12 @@ class NgxRewriteOptions : public SystemRewriteOptions {
   }
   const GoogleString& global_admin_path() const {
     return global_admin_path_.value();
+  }
+  const std::vector<RefCountedPtr<ScriptLine> >& script_lines() const {
+    return script_lines_;
+  }
+  const bool& clear_inherited_scripts() const {
+    return clear_inherited_scripts_;
   }
 
  private:
@@ -141,6 +225,9 @@ class NgxRewriteOptions : public SystemRewriteOptions {
   Option<GoogleString> messages_path_;
   Option<GoogleString> admin_path_;
   Option<GoogleString> global_admin_path_;
+
+  bool clear_inherited_scripts_;
+  std::vector<RefCountedPtr<ScriptLine> > script_lines_;
 
   // Helper for ParseAndSetOptions.  Returns whether the two directives equal,
   // ignoring case.

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -27,6 +27,7 @@ http {
   proxy_cache_path "@@PROXY_CACHE@@"  levels=1:2   keys_zone=htmlcache:60m inactive=90m  max_size=50m;
   proxy_temp_path "@@TMP_PROXY_CACHE@@";
 
+  pagespeed ProcessScriptVariables on;
   pagespeed StatisticsPath /ngx_pagespeed_statistics;
   pagespeed GlobalStatisticsPath /ngx_pagespeed_global_statistics;
   pagespeed ConsolePath /pagespeed_console;
@@ -1359,8 +1360,11 @@ http {
           https://www.gstatic.com/psa/static;
     }
 
+    # $host implicitly tests script variable support. I'd love to test it more
+    # directly, but so far this is the best I've come up with and duplicating
+    # the test doesn't seem to make sense.
     pagespeed LoadFromFile
-        "http://localhost:@@PRIMARY_PORT@@/mod_pagespeed_test/ipro/instant/"
+        "http://$host:@@PRIMARY_PORT@@/mod_pagespeed_test/ipro/instant/"
         "@@SERVER_ROOT@@/mod_pagespeed_test/ipro/instant/";
 
     pagespeed EnableFilters remove_comments;
@@ -1374,8 +1378,8 @@ http {
       "@@SERVER_ROOT@@/mod_pagespeed_test/load_from_file/file_\1/";
     pagespeed LoadFromFileRule Disallow
       "@@SERVER_ROOT@@/mod_pagespeed_test/load_from_file/file_dir/httponly/";
-    pagespeed LoadFromFileRuleMatch Disallow \.ssp.css$;
-    pagespeed LoadFromFileRuleMatch Allow exception\.ssp\.css$;
+    pagespeed LoadFromFileRuleMatch Disallow \.ssp.css$ps_dollar;
+    pagespeed LoadFromFileRuleMatch Allow exception\.ssp\.css$ps_dollar;
 
     #charset koi8-r;
 


### PR DESCRIPTION
Based on 75a4481 from master:

Add support for script variables in LoadFromFileXXX configuration to trunk-tracking,
which can be enabled by adding "pagespeed ProcessScriptVariables on" in
the http{} block. Also adds a helpful comment to ps_dollar().

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/549
Docs: https://github.com/pagespeed/ngx_pagespeed/wiki/Script-variables-in-LoadFromFile-configuration

Resolved conflicts:
    src/ngx_rewrite_driver_factory.h
    src/ngx_rewrite_options.cc
    test/nginx_system_test.sh
