### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ recompiling Tengine](https://github.com/pagespeed/ngx_pagespeed/wiki/Using-ngx_p
    $ sudo yum install gcc-c++ pcre-dev pcre-devel zlib-devel make
 
    # These are for Debian. Ubuntu will be similar.
-   $ sudo apt-get install build-essential zlib1g-dev libpcre3 libpcre3-dev
+   $ sudo apt-get install build-essential zlib1g-dev libpcre3 libpcre3-dev g++
    ```
 
 2. Download ngx_pagespeed:


### PR DESCRIPTION
g++ is also required for compilation on debian wheezy. I had to install it in order to be able to use psol, otherwise "checking for psol ... not found"
