### PR TITLE
beacon response body processing from temp file

### DIFF
--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -1123,6 +1123,16 @@ http {
   }
 
   server {
+    # Write all post data to temp files
+    client_body_in_file_only clean;
+    pagespeed CriticalImagesBeaconEnabled true;
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
+    server_name beacon-post-temp-file.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+  }
+
+  server {
     listen @@SECONDARY_PORT@@;
     listen [::]:@@SECONDARY_PORT@@;
     server_name purge.example.com;


### PR DESCRIPTION
Add support for processing beacon posts with data sizes that exceed
the default or configured client_body_buffer_size.

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/752
