### PR TITLE
testing: direct port of r4146 to fix message color issue

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -2682,15 +2682,14 @@ check fgrep -q "awaiting response... 304" $OUTFILE
 
 # Test if the warning messages are colored in message_history page.
 # We color the messages in message_history page to make it clearer to read.
-# Red for Error messages. Blue for Warning messages.
+# Red for Error messages. Brown for Warning messages.
 # Orange for Fatal messages. Black by default.
 # Won't test Error messages and Fatal messages in this test.
-# TODO(xqyin): test all the types of messages in future unit test.
 start_test Messages are colored in message_history
 INJECT=$($CURL --silent $HOSTNAME/?PageSpeed=Warning_trigger)
 OUT=$($WGET -q -O - $HOSTNAME/pagespeed_admin/message_history | \
   grep Warning_trigger)
-check_from "$OUT" fgrep -q "color:blue;"
+check_from "$OUT" fgrep -q "color:brown;"
 
 start_test Downstream cache integration caching headers.
 URL="http://downstreamcacheresource.example.com/mod_pagespeed_example/images/"


### PR DESCRIPTION
Porting [r4146](https://code.google.com/p/modpagespeed/source/detail?r=4146) from `apache/system_test.sh` fixes this error:

```
TEST: Messages are colored in message_history
     check_from fgrep -q color:blue;
FAILed Input: <pre style="color:brown; margin:0;">[Wed, 13 Aug 2014 13:54:20 GMT] [Warning] [12497] Invalid value for PageSpeed: Warning_trigger (should be on, off, unplugged, or noscript)</pre>
<pre style="margin:0;">[Wed, 13 Aug 2014 13:54:20 GMT] [Info] [12497] Trying to serve rewritten resource in-place: http://localhost:8050/?PageSpeed=Warning_trigger</pre>
<pre style="margin:0;">[Wed, 13 Aug 2014 13:54:20 GMT] [Info] [12497] Could not rewrite resource in-place because URL is not in cache: http://localhost:8050/?PageSpeed=Warning_trigger</pre>
     failure at line 2693
in 'Messages are colored in message_history'
FAIL.
With serf fetcher setup.
```
