### PR TITLE
native-fetcher: Explicitly specify a default dns resolver timeout.

### DIFF
--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -77,7 +77,7 @@ NgxRewriteDriverFactory::NgxRewriteDriverFactory(
           new NgxMessageHandler(thread_system()->NewMutex())),
       install_crash_handler_(false),
       log_(NULL),
-      resolver_timeout_(NGX_CONF_UNSET_MSEC),
+      resolver_timeout_(10000),
       use_native_fetcher_(false),
       ngx_shared_circular_buffer_(NULL),
       hostname_(hostname.as_string()),


### PR DESCRIPTION
Fixes https://github.com/pagespeed/ngx_pagespeed/issues/774 for me,
might fix https://github.com/pagespeed/ngx_pagespeed/issues/776
