### PR TITLE
Implement NgxServerContext::FormatOption so we can indicate nginx formatting in error messages

### DIFF
--- a/src/ngx_server_context.cc
+++ b/src/ngx_server_context.cc
@@ -77,4 +77,9 @@ SystemRequestContext* NgxServerContext::NewRequestContext(
                                   str_to_string_piece(local_ip));
 }
 
+GoogleString NgxServerContext::FormatOption(StringPiece option_name,
+                                            StringPiece args) {
+  return StrCat("pagespeed ", option_name, " ", args, ";");
+}
+
 }  // namespace net_instaweb

--- a/src/ngx_server_context.h
+++ b/src/ngx_server_context.h
@@ -55,6 +55,8 @@ class NgxServerContext : public SystemServerContext {
     return dynamic_cast<NgxMessageHandler*>(message_handler());
   }
 
+  virtual GoogleString FormatOption(StringPiece option_name, StringPiece args);
+
  private:
   NgxRewriteDriverFactory* ngx_factory_;
 

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -2744,6 +2744,10 @@ if [ "$NATIVE_FETCHER" != "on" ]; then
     'grep -c /https_gstatic_dot_com/1.gif.pagespeed.ce' 1
 fi
 
+start_test Base config has purging disabled.  Check error message syntax.
+OUT=$($WGET_DUMP "$HOSTNAME/pagespeed_admin/cache?purge=*")
+check_from "$OUT" fgrep -q "pagespeed EnableCachePurge on;"
+
 if $USE_VALGRIND; then
     # It is possible that there are still ProxyFetches outstanding
     # at this point in time. Give them a few extra seconds to allow


### PR DESCRIPTION
Override the method used to specify the format for conf files, so we can put an accurate error message in the admin GUI, and test it.
