### PR TITLE
script-filters: Allow using script variables in Enable/DisableFilters

### DIFF
--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -276,10 +276,11 @@ const char* NgxRewriteOptions::ParseAndSetOptions(
 
   ScriptLine* script_line;
   script_line = NULL;
-  // Only allow script variable support for LoadFromFile for now.
   // Note that LoadFromFile should not be scriptable on wildcard hosts,
   // as browsers might be able to manipulate its natural use-case: $http_host.
-  if (!StringCaseStartsWith(directive, "LoadFromFile")) {
+  if (!StringCaseStartsWith(directive, "LoadFromFile") &&
+      !StringCaseEqual(directive, "EnableFilters") &&
+      !StringCaseEqual(directive, "DisableFilters")) {
     compile_scripts = false;
   }
 


### PR DESCRIPTION
To support a non-evil way (if-in-location) of tuning SPDY specific
configuration, allow scripting of Enable/DisableFilters in nginx.conf

Example:

``` bash

http {
pagespeed ProcessScriptVariables on;
server {
    pagespeed RewriteLevel PassThrough;
    pagespeed EnableFilters rewrite_images;
    set $spdy_disable "";

    if ($spdy) {
       set $spdy_disable "rewrite_images";
    }
    pagespeed DisableFilters "$spdy_disable";
}
}
```
