### PR TITLE
gzip-rollback-message: Demote a log message from info to debug

### DIFF
--- a/src/ngx_gzip_setter.cc
+++ b/src/ngx_gzip_setter.cc
@@ -381,7 +381,7 @@ void NgxGZipSetter::AddGZipHTTPTypes(ngx_conf_t* cf) {
 }
 
 void NgxGZipSetter::RollBackAndDisable(ngx_conf_t* cf) {
-  ngx_conf_log_error(NGX_LOG_INFO, cf, 0,
+  ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0,
                      "pagespeed: rollback gzip, explicit configuration");
   for (std::vector<ngx_flag_t*>::iterator i = ngx_flags_set_.begin();
        i != ngx_flags_set_.end(); ++i) {


### PR DESCRIPTION
Should fix https://github.com/pagespeed/ngx_pagespeed/issues/832

I couldn't reproduce the problem that this was being written to stdout/stderr, but this message should be demoted anyway.  Demoting it should fix the problem if it happens on other systems as the default log level is info. 
