### PR TITLE
testing: give '-p' to mkdir

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -124,7 +124,7 @@ killall nginx
 
 TEST_TMP="$this_dir/tmp"
 rm -r "$TEST_TMP"
-check_simple mkdir "$TEST_TMP"
+check_simple mkdir -p "$TEST_TMP"
 PROXY_CACHE="$TEST_TMP/proxycache"
 TMP_PROXY_CACHE="$TEST_TMP/tmpproxycache"
 ERROR_LOG="$TEST_TMP/error.log"


### PR DESCRIPTION
rm won't remove the containing directory if a file is removed out from under it, which means the directory will still be there but will be empty.  This is not a problem, so pass '-p' to not fail on already existing directories.

This fixes problems like:

```
rm: cannot remove ‘/home/jefftk/ngx_pagespeed/test/tmp/nginx.pid’: No such file or directory
     check mkdir /home/jefftk/ngx_pagespeed/test/tmp
mkdir: cannot create directory ‘/home/jefftk/ngx_pagespeed/test/tmp’: File exists
```
