### PR TITLE
server-header: improve handling of server header

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -542,8 +542,6 @@ ngx_int_t copy_response_headers_to_ngx(
       continue;
     } else if (STR_EQ_LITERAL(name, "Transfer-Encoding")) {
       continue;
-    } else if (STR_EQ_LITERAL(name, "Server")) {
-      continue;
     }
 
     u_char* name_s = ngx_pstrdup(r->pool, &name);

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -274,6 +274,8 @@ STATISTICS_URL=http://$PRIMARY_HOSTNAME/ngx_pagespeed_statistics
 
 # An expected failure can be indicated like: "~In-place resource optimization~"
 PAGESPEED_EXPECTED_FAILURES="
+~Override server header in resource flow.~
+~Override server header in IPRO flow.~
 "
 
 # Some tests are flakey under valgrind. For now, add them to the expected
@@ -1100,6 +1102,46 @@ fi
 start_test Base config has purging disabled.  Check error message syntax.
 OUT=$($WGET_DUMP "$HOSTNAME/pagespeed_admin/cache?purge=*")
 check_from "$OUT" fgrep -q "pagespeed EnableCachePurge on;"
+
+start_test Default server header in html flow.
+URL=http://headers.example.com/mod_pagespeed_example/
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1)
+# '|| true' in the line below supresses the exit code from grep when there is no
+# match in its input (1).
+MATCHES=$(echo "$OUT" | grep -c "Server: nginx/") || true
+check [ $MATCHES -eq 1 ]
+
+start_test Default server header in resource flow.
+URL=http://headers.example.com/mod_pagespeed_example/
+URL+=combine_javascript2.js+combine_javascript1.js.pagespeed.jc.0.js
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1)
+MATCHES=$(echo "$OUT" | grep -c "Server: nginx/") || true
+check [ $MATCHES -eq 1 ]
+
+start_test Default server header in IPRO flow.
+URL=http://headers.example.com//mod_pagespeed_example/combine_javascript2.js
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1)
+MATCHES=$(echo "$OUT" | grep -c "Server: nginx/") || true
+check [ $MATCHES -eq 1 ]
+
+start_test Override server header in html flow.
+URL=http://headers.example.com/mod_pagespeed_test/whitespace.html
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1)
+MATCHES=$(echo "$OUT" | grep -c "Server: override") || true
+check [ $MATCHES -eq 1 ]
+
+start_test Override server header in resource flow.
+URL=http://headers.example.com/mod_pagespeed_test/
+URL+=A.proxy_pass.css.pagespeed.cf.0.css
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1)
+MATCHES=$(echo "$OUT" | grep -c "Server: override") || true
+check [ $MATCHES -eq 1 ]
+
+start_test Override server header in IPRO flow.
+URL=http://headers.example.com/mod_pagespeed_test/proxy_pass.css
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1)
+MATCHES=$(echo "$OUT" | grep -c "Server: override") || true
+check [ $MATCHES -eq 1 ]
 
 if $USE_VALGRIND; then
     # It is possible that there are still ProxyFetches outstanding

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -1181,6 +1181,22 @@ http {
   }
 
   server {
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
+    server_name headers.example.com;
+    root "@@SERVER_ROOT@@";
+    pagespeed FileCachePath "@@FILE_CACHE@@_purge";
+    pagespeed RewriteLevel CoreFilters;
+
+    pagespeed InPlaceRewriteDeadlineMs -1;
+    pagespeed LoadFromFile "http://headers.example.com/"
+              "@@SERVER_ROOT@@/";
+    location /mod_pagespeed_test/ {
+      more_set_headers "Server: overriden";
+    }
+  }
+
+  server {
     listen @@PRIMARY_PORT@@;
     listen [::]:@@PRIMARY_PORT@@;
     server_name  localhost;


### PR DESCRIPTION
- Fixes an issue in the html flow that would prevent overriding the
value of the 'Server' response-header.
- Add tests that ensure we emit a single and correct server header
in all flows when not overriding it.
- Add tests that ensure overriding the 'Server' response header
works. The resource and IPRO flow are added to the expected failures
as those are not working yet (and will be adressed in a follow-up).

Fixed https://github.com/pagespeed/ngx_pagespeed/issues/864 (html flow)