### PR TITLE
Release base fetch early, eliminate write_pending and fetch_done

### DIFF
--- a/src/ngx_base_fetch.cc
+++ b/src/ngx_base_fetch.cc
@@ -105,14 +105,8 @@ void NgxBaseFetch::ReadCallback(const ps_event_data& data) {
     return;
   }
   ps_request_ctx_t* ctx = ps_get_request_context(r);
+
   CHECK(data.sender == ctx->base_fetch);
-
-  // ngx_base_fetch_handler() ends up setting ctx->fetch_done, which
-  // means we shouldn't call it anymore.
-  if (ctx->fetch_done) {
-    return;
-  }
-
   CHECK(r->count > 0) << "r->count: " << r->count;
 
   int rc;

--- a/src/ngx_pagespeed.h
+++ b/src/ngx_pagespeed.h
@@ -89,9 +89,6 @@ typedef struct {
   bool html_rewrite;
   bool in_place;
 
-  bool write_pending;
-  bool fetch_done;
-
   PreserveCachingHeaders preserve_caching_headers;
 
   // for html rewrite


### PR DESCRIPTION
Get rid of write_pending & fetch_done flags on the request context.
Assume that having ctx->base_fetch set means we have outstanding
work and thus we are not done yet, for simplicity.
This also means we'll release the base fetch earlier which seems
like a good idea to me.