### PR TITLE
content-handling-errors: fall back to nginx's default handling

### DIFF
--- a/src/ngx_base_fetch.h
+++ b/src/ngx_base_fetch.h
@@ -116,6 +116,7 @@ class NgxBaseFetch : public AsyncFetch {
   bool detached() { return detached_; }
 
   ngx_http_request_t* request() { return request_; }
+  NgxBaseFetchType base_fetch_type() { return base_fetch_type_; }
 
  private:
   virtual bool HandleWrite(const StringPiece& sp, MessageHandler* handler);

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1143,6 +1143,16 @@ OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1)
 MATCHES=$(echo "$OUT" | grep -c "Server: override") || true
 check [ $MATCHES -eq 1 ]
 
+start_test Conditional cache-control header override in resource flow.
+URL=http://headers.example.com/mod_pagespeed_test/
+URL+=A.doesnotexist.css.pagespeed.cf.0.css
+# The 404 response makes wget exit with an error code, which we ignore.
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1) || true
+# We ignored the exit code, check if we got a 404 response.
+check_from "$OUT" fgrep -qi '404'
+MATCHES=$(echo "$OUT" | grep -c "Cache-Control: override") || true
+check [ $MATCHES -eq 1 ]
+
 if $USE_VALGRIND; then
     # It is possible that there are still ProxyFetches outstanding
     # at this point in time. Give them a few extra seconds to allow

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -1192,7 +1192,8 @@ http {
     pagespeed LoadFromFile "http://headers.example.com/"
               "@@SERVER_ROOT@@/";
     location /mod_pagespeed_test/ {
-      more_set_headers "Server: overriden";
+      more_set_headers "Server: override";
+      more_set_headers -s '404' 'Cache-Control: override';
     }
   }
 


### PR DESCRIPTION
This change passes on non succesful status codes for pagespeed
resources and other places where we act as a content handler to
nginx. This has two benefits:
- Instead of a blank page, the user agent receives a formatted
  and (hopefully customized and informative) response.
- Header modules are able to operate on that response, which was
  requested in https://github.com/pagespeed/ngx_pagespeed/issues/612#issuecomment-58855816