### PR TITLE
Support for pushState(); and popState(); ajax loaded sites

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -1816,7 +1816,10 @@ ngx_int_t ps_resource_handler(ngx_http_request_t* r,
   GoogleString url_string = ps_determine_url(r);
   GoogleUrl url(url_string);
 
-  CHECK(url.IsWebValid());
+  if (!url.IsWebValid()) {
+    ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "invalid url");
+    return NGX_DECLINED;
+  }
 
   scoped_ptr<RequestHeaders> request_headers(new RequestHeaders);
   scoped_ptr<ResponseHeaders> response_headers(new ResponseHeaders);


### PR DESCRIPTION
My newest project is using pushState(), and popState(); and it loads only the changing middle part of the page instead of reloading it entirely. This is not really supported by pagespeed.

Watch my example.
https://mysexyescort.de/

Plus why its it impossible to send expire headers to clients when running pagespeed?
I 'd like to cache their get requests for 2 minutes or so.

