### PR TITLE
module-position: optional switch to install at HTTP_AUX_FILTER_MODULES

### DIFF
--- a/config
+++ b/config
@@ -17,6 +17,8 @@
 #   PSOL_BINARY: absolute path to pagespeed_automatic.a
 
 mod_pagespeed_dir="${MOD_PAGESPEED_DIR:-unset}"
+position_aux="${POSITION_AUX:-unset}"
+
 if [ "$mod_pagespeed_dir" = "unset" ] ; then
   mod_pagespeed_dir="$ngx_addon_dir/psol/include"
   build_from_source=false
@@ -195,9 +197,14 @@ if [ $ngx_found = yes ]; then
     $ps_src/ngx_server_context.cc \
     $ps_src/ngx_url_async_fetcher.cc"
 
-  # Make pagespeed run immediately before gzip.
-  HTTP_FILTER_MODULES=$(echo $HTTP_FILTER_MODULES |\
-    sed "s/$HTTP_GZIP_FILTER_MODULE/$HTTP_GZIP_FILTER_MODULE $ngx_addon_name/")
+  if [ "$position_aux" = "true" ] ; then
+     HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES $ngx_addon_name"
+  else
+    # Make pagespeed run immediately before gzip.
+    HTTP_FILTER_MODULES=$(echo $HTTP_FILTER_MODULES |\
+      sed "s/$HTTP_GZIP_FILTER_MODULE/$HTTP_GZIP_FILTER_MODULE $ngx_addon_name/")
+  fi
+
   # Make the etag header filter run immediately after gzip.
   HTTP_FILTER_MODULES=$(echo $HTTP_FILTER_MODULES |\
     sed "s/$HTTP_GZIP_FILTER_MODULE/ngx_pagespeed_etag_filter $HTTP_GZIP_FILTER_MODULE/")

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -33,6 +33,7 @@
 : ${SECONDARY_PORT:?"Set SECONDARY_PORT"}
 : ${MOD_PAGESPEED_DIR:?"Set MOD_PAGESPEED_DIR"}
 : ${NGINX_EXECUTABLE:?"Set NGINX_EXECUTABLE"}
+POSITION_AUX="${POSITION_AUX:-unset}"
 
 PRIMARY_HOSTNAME="localhost:$PRIMARY_PORT"
 SECONDARY_HOSTNAME="localhost:$SECONDARY_PORT"
@@ -273,10 +274,14 @@ BEACON_HANDLER="ngx_pagespeed_beacon"
 STATISTICS_URL=http://$PRIMARY_HOSTNAME/ngx_pagespeed_statistics
 
 # An expected failure can be indicated like: "~In-place resource optimization~"
-PAGESPEED_EXPECTED_FAILURES="
-~Override server header in resource flow.~
-~Override server header in IPRO flow.~
+PAGESPEED_EXPECTED_FAILURES=""
+
+if [ "$POSITION_AUX" = "true" ] ; then
+  PAGESPEED_EXPECTED_FAILURES+="
+~server-side includes~
 "
+fi
+
 
 # Some tests are flakey under valgrind. For now, add them to the expected
 # failures when running under valgrind.
@@ -1130,18 +1135,20 @@ OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1)
 MATCHES=$(echo "$OUT" | grep -c "Server: override") || true
 check [ $MATCHES -eq 1 ]
 
-start_test Override server header in resource flow.
-URL=http://headers.example.com/mod_pagespeed_test/
-URL+=A.proxy_pass.css.pagespeed.cf.0.css
-OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1)
-MATCHES=$(echo "$OUT" | grep -c "Server: override") || true
-check [ $MATCHES -eq 1 ]
+if [ "$POSITION_AUX" = "true" ] ; then
+  start_test Override server header in resource flow.
+  URL=http://headers.example.com/mod_pagespeed_test/
+  URL+=A.proxy_pass.css.pagespeed.cf.0.css
+  OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1)
+  MATCHES=$(echo "$OUT" | grep -c "Server: override") || true
+  check [ $MATCHES -eq 1 ]
 
-start_test Override server header in IPRO flow.
-URL=http://headers.example.com/mod_pagespeed_test/proxy_pass.css
-OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1)
-MATCHES=$(echo "$OUT" | grep -c "Server: override") || true
-check [ $MATCHES -eq 1 ]
+  start_test Override server header in IPRO flow.
+  URL=http://headers.example.com/mod_pagespeed_test/proxy_pass.css
+  OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1)
+  MATCHES=$(echo "$OUT" | grep -c "Server: override") || true
+  check [ $MATCHES -eq 1 ]
+fi
 
 start_test Conditional cache-control header override in resource flow.
 URL=http://headers.example.com/mod_pagespeed_test/

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -883,7 +883,10 @@ http {
     pagespeed FileCachePath "@@SECONDARY_CACHE@@";
     pagespeed RewriteLevel PassThrough;
     pagespeed on;
-    add_header PageSpeedFilters add_instrumentation;
+    location / {
+      proxy_pass http://localhost:@@SECONDARY_PORT@@;
+      proxy_set_header Host "enable-filter-header-origin.example.com";
+    }
   }
 
   server {
@@ -893,7 +896,24 @@ http {
     pagespeed FileCachePath "@@SECONDARY_CACHE@@";
     pagespeed EnableFilters add_instrumentation;
     pagespeed on;
-    add_header PageSpeed off;
+    location / {
+      proxy_pass http://localhost:@@SECONDARY_PORT@@;
+      proxy_set_header Host "pagespeed-off-header-origin.example.com";
+    }
+  }
+
+  server {
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
+    server_name headers.example.com;
+    pagespeed InPlaceRewriteDeadlineMs -1;
+    pagespeed FileCachePath "@@SECONDARY_CACHE@@";
+    pagespeed LoadFromFile "http://headers.example.com/"
+              "@@SERVER_ROOT@@/";
+    location /mod_pagespeed_test/ {
+      more_set_headers "Server: override";
+      more_set_headers -s '404' 'Cache-Control: override';
+    }
   }
 
   server {
@@ -976,7 +996,7 @@ http {
     listen [::]:@@SECONDARY_PORT@@;
     server_name date.example.com;
     pagespeed FileCachePath "@@FILE_CACHE@@";
-    add_header "Date" "Date: Fri, 16 Oct 2009 23:05:07 GMT";
+    add_header "Date" "Fri, 16 Oct 2009 23:05:07 GMT";
   }
 
   server {
@@ -1183,17 +1203,41 @@ http {
   server {
     listen @@SECONDARY_PORT@@;
     listen [::]:@@SECONDARY_PORT@@;
-    server_name headers.example.com;
+    server_name  cc-header-origin.example.com;
+    pagespeed InPlaceResourceOptimization off;
+    pagespeed off;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
     root "@@SERVER_ROOT@@";
-    pagespeed FileCachePath "@@FILE_CACHE@@_purge";
-    pagespeed RewriteLevel CoreFilters;
+    location /mod_pagespeed_test/nostore {
+      add_header "Cache-Control" "max-age=12345";
+      add_header "Cache-Control" "public, no-store";
+      add_header "Cache-Control" "max-age=14";
+    }
+  }
 
-    pagespeed InPlaceRewriteDeadlineMs -1;
-    pagespeed LoadFromFile "http://headers.example.com/"
-              "@@SERVER_ROOT@@/";
-    location /mod_pagespeed_test/ {
-      more_set_headers "Server: override";
-      more_set_headers -s '404' 'Cache-Control: override';
+  server {
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
+    server_name  enable-filter-header-origin.example.com;
+    pagespeed InPlaceResourceOptimization off;
+    pagespeed off;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    root "@@SERVER_ROOT@@";
+    location / {
+      add_header "PageSpeedFilters" "add_instrumentation";
+    }
+  }
+
+  server {
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
+    server_name  pagespeed-off-header-origin.example.com;
+    pagespeed InPlaceResourceOptimization off;
+    pagespeed off;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    root "@@SERVER_ROOT@@";
+    location / {
+      add_header "PageSpeed" "off";
     }
   }
 
@@ -1286,9 +1330,8 @@ http {
     pagespeed AvoidRenamingIntrospectiveJavascript off;
 
     location /mod_pagespeed_test/nostore {
-      add_header "Cache-Control" "max-age=12345";
-      add_header "Cache-Control" "public, no-store";
-      add_header "Cache-Control" "max-age=14";
+      proxy_pass http://localhost:@@SECONDARY_PORT@@;
+      proxy_set_header Host "cc-header-origin.example.com";
     }
 
     location /mod_pagespeed_test/forbid_all_disabled/disabled {


### PR DESCRIPTION
This change adds a flag to optionally position the module at HTTP_AUX_FILTER_MODULES
instead of just in front of the gzip module. Doing so allows header module(s) to
fully manipulate any response headers before they are send to the user-agent.
With https://github.com/pagespeed/ngx_pagespeed/pull/880, SSI no longer hangs,
and other modules using subrequests should not do so either. SSI subrequests are
not optimized when ngx_pagespeed runs at HTTP_AUX_FILTER_MODULES, so the test for
it is added to the expected failures when the tests are run for this module position.

To build with the module respositioned:
  POSITION_AUX=true ./configure ......
The same variable can be set before running the system tests, in which case it will
perform additional header tests and add the SSI test to the expected failures.