### PR TITLE
native-fetcher: fix a few bugs

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1221,7 +1221,7 @@ fi
 start_test Logged output looks healthy.
 
 # TODO(oschaaf): Sanity check for all the warnings/errors here.
-OUT=$(cat "test/tmp/error.log" \
+OUT=$(cat "$ERROR_LOG" \
     | grep "\\[" \
     | grep -v "\\[debug\\]" \
     | grep -v "\\[info\\]" \
@@ -1263,7 +1263,7 @@ OUT=$(cat "test/tmp/error.log" \
     | grep -v "\\[error\\].*Failed to make directory*" \
     | grep -v "\\[error\\].*Could not create directories*" \
     | grep -v "\\[error\\].*opening temp file: No such file or directory.*" \
-    | grep -v "\\[error\\].*unexpected response.*" \
+    | grep -v "\\[warn\\].*failed to hook next event.*" \
     || true)
 
 check [ -z "$OUT" ]

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -40,7 +40,7 @@ http {
   pagespeed MessageBufferSize 200000;
   # Increase the default fetcher timeout to resolve sporadic flakeyness when
   # the native fetcher uses 8.8.8.8 to resolve.
-  pagespeed FetcherTimeoutMs 30000;
+  pagespeed FetcherTimeoutMs 10000;
   pagespeed NativeFetcherMaxKeepaliveRequests 50;
 
   root "@@SERVER_ROOT@@";


### PR DESCRIPTION
While starting to look into https://github.com/pagespeed/ngx_pagespeed/issues/918,
I noticed a few things that looked off. So:

- Add handling for header only responses
- Fixup i/o event handling
- Fixup NgxFetch's state transitions while handling i/o

Should help stabilizing (valgrind) test runs some more.
Native-fetcher specific tests will be added as a follow-up to this, after sorting out #918 .