### PR TITLE
native-fetcher: fixes

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -3067,9 +3067,6 @@ ngx_int_t ps_init_child_process(ngx_cycle_t* cycle) {
     }
   }
 
-  if (!cfg_m->driver_factory->InitNgxUrlAsyncFetchers()) {
-    return NGX_ERROR;
-  }
   cfg_m->driver_factory->StartThreads();
   return NGX_OK;
 }

--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -152,18 +152,6 @@ RewriteOptions* NgxRewriteDriverFactory::NewRewriteOptions() {
   return options;
 }
 
-bool NgxRewriteDriverFactory::InitNgxUrlAsyncFetchers() {
-  log_ = ngx_cycle->log;
-  for (size_t i = 0; i < ngx_url_async_fetchers_.size(); ++i) {
-    // TODO(oschaaf): Can we pass the log from the server{} block here?
-    if (!ngx_url_async_fetchers_[i]->Init(
-      const_cast<ngx_cycle_t*>(ngx_cycle))) {
-      return false;
-    }
-  }
-  return true;
-}
-
 bool NgxRewriteDriverFactory::CheckResolver() {
   if (use_native_fetcher_ && resolver_ == NULL) {
     return false;
@@ -221,6 +209,7 @@ void NgxRewriteDriverFactory::StartThreads() {
 }
 
 void NgxRewriteDriverFactory::LoggingInit(ngx_log_t* log) {
+  log_ = log;
   net_instaweb::log_message_handler::Install(log);
   if (install_crash_handler()) {
     NgxMessageHandler::InstallCrashHandler(log);

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -62,7 +62,6 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   // NgxRewriteOptions.
   virtual RewriteOptions* NewRewriteOptions();
   virtual ServerContext* NewDecodingServerContext();
-  bool InitNgxUrlAsyncFetchers();
   // Check resolver configured or not.
   bool CheckResolver();
 


### PR DESCRIPTION
- Native fetching broke in https://github.com/pagespeed/ngx_pagespeed/pull/925
  Make changes so we can do early-stage fetches in the startup process
  to fix that.
- Properly cancel out any pending fetches upon ShutDown()
- Decline fetching after ShutDown(), decline fetching when Init()
  failed.