### PR TITLE
shutdown-and-flushing: Improve shutdown, support/test FlushHtml

### DIFF
--- a/src/ngx_base_fetch.h
+++ b/src/ngx_base_fetch.h
@@ -118,11 +118,13 @@ class NgxBaseFetch : public AsyncFetch {
   // this to be able to handle events which nginx request context has been
   // released while the event was in-flight.
   void Detach() { detached_ = true; DecrementRefCount(); }
+  static void CheckShutdownEvent();
 
   bool detached() { return detached_; }
 
   ngx_http_request_t* request() { return request_; }
   NgxBaseFetchType base_fetch_type() { return base_fetch_type_; }
+  static int64 request_ctx_count;
 
  private:
   virtual bool HandleWrite(const StringPiece& sp, MessageHandler* handler);
@@ -149,11 +151,11 @@ class NgxBaseFetch : public AsyncFetch {
   // Called by Done() and Release().  Decrements our reference count, and if
   // it's zero we delete ourself.
   int DecrefAndDeleteIfUnreferenced();
-
   static NgxEventConnection* event_connection;
+  static ngx_event_t* shutdown_event;
   
   // Live count of NgxBaseFetch instances that are currently in use.
-  static int active_base_fetches;
+  static int64 active_base_fetches;
 
   ngx_http_request_t* request_;
   GoogleString buffer_;

--- a/src/ngx_fetch.cc
+++ b/src/ngx_fetch.cc
@@ -508,11 +508,13 @@ bool NgxFetch::ParseUrl() {
   url_.url.len = str_url_.length();
   url_.url.data = static_cast<u_char*>(ngx_palloc(pool_, url_.url.len));
   if (url_.url.data == NULL) {
+    DCHECK(false) << "NgxFetch::ParseUrl() without data";
     return false;
   }
   str_url_.copy(reinterpret_cast<char*>(url_.url.data), str_url_.length(), 0);
-
-  return NgxUrlAsyncFetcher::ParseUrl(&url_, pool_);
+  bool r = NgxUrlAsyncFetcher::ParseUrl(&url_, pool_);
+  DCHECK(r) << "NgxUrlAsyncFetcher::ParseUrl(&url_, pool_) failed";
+  return r; 
 }
 
 // Issue a request after the resolver is done

--- a/src/ngx_pagespeed.h
+++ b/src/ngx_pagespeed.h
@@ -52,7 +52,7 @@ class InPlaceResourceRecorder;
 // NGX_DECLINED immediately unless send_last_buf.
 ngx_int_t string_piece_to_buffer_chain(
     ngx_pool_t* pool, StringPiece sp,
-    ngx_chain_t** link_ptr, bool send_last_buf);
+    ngx_chain_t** link_ptr, bool send_last_buf, bool flush);
 
 StringPiece str_to_string_piece(ngx_str_t s);
 
@@ -103,6 +103,7 @@ typedef struct {
   // We need to remember the URL here as well since we may modify what NGX
   // gets by stripping our special query params and honoring X-Forwarded-Proto.
   GoogleString url_string;
+  bool follow_flushes;
 } ps_request_ctx_t;
 
 ps_request_ctx_t* ps_get_request_context(ngx_http_request_t* r);

--- a/test/nginx_terminate_timeout.diff
+++ b/test/nginx_terminate_timeout.diff
@@ -1,0 +1,59 @@
+diff --git a/src/core/nginx.c b/src/core/nginx.c
+index c75ee4f..2b8f959 100644
+--- a/src/core/nginx.c
++++ b/src/core/nginx.c
+@@ -125,6 +125,13 @@ static ngx_command_t  ngx_core_commands[] = {
+       offsetof(ngx_core_conf_t, rlimit_sigpending),
+       NULL },
+ 
++    { ngx_string("child_terminate_timeout"),
++      NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
++      ngx_conf_set_msec_slot,
++      0,
++      offsetof(ngx_core_conf_t, child_terminate_timeout),
++      NULL },
++
+     { ngx_string("working_directory"),
+       NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
+       ngx_conf_set_str_slot,
+@@ -955,6 +962,7 @@ ngx_core_module_create_conf(ngx_cycle_t *cycle)
+     ccf->rlimit_nofile = NGX_CONF_UNSET;
+     ccf->rlimit_core = NGX_CONF_UNSET;
+     ccf->rlimit_sigpending = NGX_CONF_UNSET;
++    ccf->child_terminate_timeout = NGX_CONF_UNSET_MSEC;
+ 
+     ccf->user = (ngx_uid_t) NGX_CONF_UNSET_UINT;
+     ccf->group = (ngx_gid_t) NGX_CONF_UNSET_UINT;
+@@ -985,6 +993,7 @@ ngx_core_module_init_conf(ngx_cycle_t *cycle, void *conf)
+ 
+     ngx_conf_init_value(ccf->worker_processes, 1);
+     ngx_conf_init_value(ccf->debug_points, 0);
++    ngx_conf_init_value(ccf->child_terminate_timeout, 1000);
+ 
+ #if (NGX_HAVE_CPU_AFFINITY)
+ 
+diff --git a/src/core/ngx_cycle.h b/src/core/ngx_cycle.h
+index 21bf5ca..cd983ff 100644
+--- a/src/core/ngx_cycle.h
++++ b/src/core/ngx_cycle.h
+@@ -85,6 +85,7 @@ typedef struct {
+      ngx_int_t                rlimit_sigpending;
+      off_t                    rlimit_core;
+ 
++     ngx_msec_t               child_terminate_timeout;
+      int                      priority;
+ 
+      ngx_uint_t               cpu_affinity_n;
+diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
+index 51cf725..7d2f4c2 100644
+--- a/src/os/unix/ngx_process_cycle.c
++++ b/src/os/unix/ngx_process_cycle.c
+@@ -200,7 +200,7 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
+ 
+             sigio = ccf->worker_processes + 2 /* cache processes */;
+ 
+-            if (delay > 1000) {
++            if (delay > ccf->child_terminate_timeout) {
+                 ngx_signal_worker_processes(cycle, SIGKILL);
+             } else {
+                 ngx_signal_worker_processes(cycle,

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -6,6 +6,10 @@ worker_processes  1;
 
 daemon @@DAEMON@@;
 master_process on;
+child_terminate_timeout @@CHILD_TERMINATE_MAX_SECONDS@@s;
+
+worker_rlimit_core 1024M;
+working_directory "@@TEST_TMP@@/";
 
 error_log "@@ERROR_LOG@@" debug;
 pid "@@TEST_TMP@@/nginx.pid";
@@ -1208,6 +1212,48 @@ http {
     server_name proxy-post-origin.example.com;
     pagespeed FileCachePath "@@FILE_CACHE@@";
     root "@@SERVER_ROOT@@";
+  }
+
+  server {
+    pagespeed on;
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
+    server_name flush.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    pagespeed RewriteLevel PassThrough;
+    root "@@TEST_TMP@@/../www/";
+    pagespeed RewriteDeadlinePerFlushMs 1;
+    pagespeed FollowFlushes on;
+
+    location ~ \.php$ {
+      fastcgi_param SCRIPT_FILENAME $request_filename;
+      fastcgi_param QUERY_STRING $query_string;
+      fastcgi_param REQUEST_METHOD $request_method;
+      fastcgi_param CONTENT_TYPE $content_type;
+      fastcgi_param CONTENT_LENGTH $content_length;
+      fastcgi_pass 127.0.0.1:9000;
+      fastcgi_buffering off;
+    }
+  }
+  server {
+    pagespeed on;
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
+    server_name noflush.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    pagespeed RewriteLevel PassThrough;
+    root "@@TEST_TMP@@/../www/";
+    pagespeed FollowFlushes off;
+
+    location ~ \.php$ {
+      fastcgi_param SCRIPT_FILENAME $request_filename;
+      fastcgi_param QUERY_STRING $query_string;
+      fastcgi_param REQUEST_METHOD $request_method;
+      fastcgi_param CONTENT_TYPE $content_type;
+      fastcgi_param CONTENT_LENGTH $content_length;
+      fastcgi_pass 127.0.0.1:9000;
+      fastcgi_buffering off;
+    }
   }
 
   server {

--- a/test/www/slow-flushing-html-response.php
+++ b/test/www/slow-flushing-html-response.php
@@ -1,0 +1,15 @@
+<?php
+header('Content-Type: text/html');
+
+echo "<html><head></head><body>\n";
+$size = 5;
+
+for($i = 1; $i <= $size; $i++) {
+  echo "<p>foo</p><div>bar:" . $i  . "</div>\n";
+  ob_flush();
+  flush();
+  sleep(1);
+}
+
+echo "</body></html>\n";
+?>


### PR DESCRIPTION
shutdown-and-flushing: Improve shutdown, support/test FlushHtml

```
- Improve shutting down both gracefully and quickly
- Set the flush flags on buffers when FlushHtml is on for optimized
  html responses
- Add tests for these features
- Don't call proxy_fetch->Flush() each time our body filter is called,
  because that would only make sense if we'd also set buf->flush.
```

Needs changes in PSOL, which are pending review.
