### PR TITLE
change location of pagespeed_automatic.a in config

### DIFF
--- a/config
+++ b/config
@@ -105,7 +105,7 @@ psol_binary="${PSOL_BINARY:-unset}"
 if [ "$psol_binary" = "unset" ] ; then
   if $build_from_source ; then
     psol_binary="\
-        $mod_pagespeed_dir/pagespeed/automatic/pagespeed_automatic.a"
+        $mod_pagespeed_dir/net/instaweb/automatic/pagespeed_automatic.a"
   else
     psol_library_dir="$ngx_addon_dir/psol/lib/$buildtype/$os_name/$arch_name"
     psol_binary="$psol_library_dir/pagespeed_automatic.a"


### PR DESCRIPTION
config had location of pagespeed_automatic.a in the wrong location when
building PSOL from source.

change to `$mod_pagespeed_dir/net/instaweb/automatic/pagespeed_automatic.a`