### PR TITLE
config: whitelist a few more directives for script variables

### DIFF
--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -280,7 +280,11 @@ const char* NgxRewriteOptions::ParseAndSetOptions(
   // as browsers might be able to manipulate its natural use-case: $http_host.
   if (!StringCaseStartsWith(directive, "LoadFromFile") &&
       !StringCaseEqual(directive, "EnableFilters") &&
-      !StringCaseEqual(directive, "DisableFilters")) {
+      !StringCaseEqual(directive, "DisableFilters") &&
+      !StringCaseEqual(directive, "DownstreamCachePurgeLocationPrefix") &&
+      !StringCaseEqual(directive, "DownstreamCachePurgeMethod") &&
+      !StringCaseEqual(directive,
+                       "DownstreamCacheRewrittenPercentageThreshold")) {
     compile_scripts = false;
   }
 


### PR DESCRIPTION
When configuring downstream caching if you have an origin with multiple caches in front of it you might want to choose how you handle requests in response to which cache you're getting them from.  White-list `DownstreamCachePurgeLocationPrefix`, `DownstreamCachePurgeMethod`, and `DownstreamCacheRewrittenPercentageThreshold` for scripting so this is possible.

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/903