### PR TITLE
simple_handler: pass through error codes

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -2643,8 +2643,7 @@ ngx_int_t ps_simple_handler(ngx_http_request_t* r,
     }
   }
 
-  send_out_headers_and_body(r, response_headers, output);
-  return NGX_OK;
+  return send_out_headers_and_body(r, response_headers, output);
 }
 
 void ps_beacon_handler_helper(ngx_http_request_t* r,


### PR DESCRIPTION
For https://github.com/pagespeed/ngx_pagespeed/issues/957
I can't reproduce the problem on my machine yet, but I think it is
worth trying to see if this change fixes the issue.