### PR TITLE
Support script variables in ShardDomain

### DIFF
--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -284,7 +284,8 @@ const char* NgxRewriteOptions::ParseAndSetOptions(
       !StringCaseEqual(directive, "DownstreamCachePurgeLocationPrefix") &&
       !StringCaseEqual(directive, "DownstreamCachePurgeMethod") &&
       !StringCaseEqual(directive,
-                       "DownstreamCacheRewrittenPercentageThreshold")) {
+                       "DownstreamCacheRewrittenPercentageThreshold") &&
+      !StringCaseEqual(directive, "ShardDomain")){
     compile_scripts = false;
   }
 

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1150,6 +1150,19 @@ HEADERS="--header=Host:script-filters.example.com"
 OUT=$($WGET_DUMP -S $HEADERS $URL 2>&1)
 check_not_from "$OUT" fgrep -qi 'addInstrumentationInit'
 
+start_test Test that we can modify domain sharding via script variables.
+URL="http://$SECONDARY_HOSTNAME/mod_pagespeed_example/rewrite_images.html"
+HEADERS="--header=Host:script-filters.example.com"
+OUT=$($WGET_DUMP -S $HEADERS $URL 2>&1)
+check_from "$OUT" fgrep "http://cdn1.example.com"
+check_from "$OUT" fgrep "http://cdn2.example.com"
+
+URL="http://$SECONDARY_HOSTNAME/mod_pagespeed_example/rewrite_images.html"
+HEADERS="--header=Host:script-filters.example.com --header=X-Script:1"
+OUT=$($WGET_DUMP -S $HEADERS $URL 2>&1)
+check_not_from "$OUT" fgrep "http://cdn1.example.com"
+check_not_from "$OUT" fgrep "http://cdn2.example.com"
+
 if [ "$NATIVE_FETCHER" != "on" ]; then
   start_test Test that we can rewrite an HTTPS resource.
   fetch_until $TEST_ROOT/https_fetch/https_fetch.html \

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -1252,11 +1252,15 @@ http {
     pagespeed FileCachePath "@@FILE_CACHE@@";
     root "@@SERVER_ROOT@@";
     set $filters "";
+    set $domain_shards "cdn1.example.com,cdn2.example.com";
     if ($http_X_Script) {
         set $filters "add_instrumentation";
+        set $domain_shards "";
     }
     pagespeed RewriteLevel PassThrough;
+    pagespeed EnableFilters rewrite_domains;
     pagespeed EnableFilters $filters;
+    pagespeed ShardDomain script-filters.example.com "$domain_shards";
   }
 
   server {


### PR DESCRIPTION
We want this so people can turn off ShardDomain with http2/spdy.

This change also depends on a small change in PSOL:

```
rewriter/rewrite_options.cc:
  RewriteOptions::ParseAndSetOptionFromName2(
     } else if (StringCaseEqual(name, kMapRewriteDomain)) {
       WriteableDomainLawyer()->AddRewriteDomainMapping(arg1, arg2, handler);
     } else if (StringCaseEqual(name, kShardDomain)) {
  -    WriteableDomainLawyer()->AddShard(arg1, arg2, handler);
  +    if (arg2.empty()) {
  +      // We allow people to put:
  +      //   pagespeed ShardDomain domain_to_shard "";
  +      // because we want people to be able to use script variables in nginx to
  +      // disable domain sharding with spdy/http2.
  +      // See pagespeed/module/https_support#h2_configuration_nginx
  +    } else {
  +      WriteableDomainLawyer()->AddShard(arg1, arg2, handler);
  +    }
     } else {
       result = RewriteOptions::kOptionNameUnknown;
     }
```