### PR TITLE
suppress errors on new 2-pass and 3-pass ipro tests

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -308,6 +308,8 @@ STATISTICS_URL=http://$PRIMARY_HOSTNAME/ngx_pagespeed_statistics
 # An expected failure can be indicated like: "~In-place resource optimization~"
 PAGESPEED_EXPECTED_FAILURES="
 ~Cache purging with PageSpeed off in vhost, but on in directory.~
+~2-pass ipro with long ModPagespeedInPlaceRewriteDeadline~
+~3-pass ipro with short ModPagespeedInPlaceRewriteDeadline~
 "
 
 if [ "$POSITION_AUX" = "true" ] ; then

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -1655,6 +1655,30 @@ http {
       expires 5m;
     }
 
+    location /mod_pagespeed_test/ipro/wait/ {
+      # TODO(jmarantz): ModPagespeedInPlaceWaitForOptimized should be superfluous,
+      # or made equivalent to ModPagespeedInPlaceRewriteDeadlineMs -1, which waits
+      # forever.  Otherwise ModPagespeedInPlaceRewriteDeadlineMs should just have
+      # the specified deadline.
+      # # See https://github.com/pagespeed/mod_pagespeed/issues/1171 for more
+      # detailed discussion.
+      pagespeed InPlaceWaitForOptimized on;
+    }
+
+    location /mod_pagespeed_test/ipro/wait/long/ {
+      # Make the deadline long here for valgrind tests.  We could
+      # conditionalize this.
+      pagespeed InPlaceRewriteDeadlineMs 10000;
+    }
+
+    location /mod_pagespeed_test/ipro/wait/short/ {
+      pagespeed EnableFilters in_place_optimize_for_browser;
+
+      # Make the deadline short here as we expect to always miss it
+      # in tests.
+      pagespeed InPlaceRewriteDeadlineMs 1;
+    }
+
     location /mod_pagespeed_test/ipro/instant/wait/ {
       pagespeed InPlaceWaitForOptimized on;
 


### PR DESCRIPTION
Checking this in proactively will help me make a mod_pagespeed test change without breaking the nginx tests.
