### PR TITLE
Eliminate CHECK that fails (rarely) during the IPRO lookup.

### DIFF
--- a/src/ngx_base_fetch.cc
+++ b/src/ngx_base_fetch.cc
@@ -164,15 +164,13 @@ void NgxBaseFetch::ReadCallback(const ps_event_data& data) {
       return;
   }
 
-  CHECK(r->count > 0) << "r->count: " << r->count;
-
   int rc;
   // If we are unlucky enough to have our connection finalized mid-ipro-lookup,
   // we must enter a different flow. Also see ps_in_place_check_header_filter().
   if ((ctx->base_fetch->base_fetch_type_ != kIproLookup)
       && r->connection->error) {
     ngx_log_error(NGX_LOG_DEBUG, ngx_cycle->log, 0,
-      "pagespeed [%p] request already finalized", r);
+      "pagespeed [%p] request already finalized %d", r, r->count);
     rc = NGX_ERROR;
   } else {
     rc = ps_base_fetch::ps_base_fetch_handler(r);
@@ -186,8 +184,11 @@ void NgxBaseFetch::ReadCallback(const ps_event_data& data) {
 
   ngx_connection_t* c = r->connection;
   ngx_http_finalize_request(r, rc);
-  // See http://forum.nginx.org/read.php?2,253006,253061
-  ngx_http_run_posted_requests(c);
+
+  if (!r->connection->error) {
+    // See http://forum.nginx.org/read.php?2,253006,253061
+    ngx_http_run_posted_requests(c);
+  }
 }
 
 void NgxBaseFetch::Lock() {


### PR DESCRIPTION
Fixes https://github.com/pagespeed/ngx_pagespeed/issues/1096