### PR TITLE
Fix valgrind complaint caused by NgxBaseFetch

### DIFF
--- a/src/ngx_base_fetch.cc
+++ b/src/ngx_base_fetch.cc
@@ -165,6 +165,7 @@ void NgxBaseFetch::ReadCallback(const ps_event_data& data) {
   }
 
   int rc;
+  bool run_posted = true;
   // If we are unlucky enough to have our connection finalized mid-ipro-lookup,
   // we must enter a different flow. Also see ps_in_place_check_header_filter().
   if ((ctx->base_fetch->base_fetch_type_ != kIproLookup)
@@ -172,6 +173,7 @@ void NgxBaseFetch::ReadCallback(const ps_event_data& data) {
     ngx_log_error(NGX_LOG_DEBUG, ngx_cycle->log, 0,
       "pagespeed [%p] request already finalized %d", r, r->count);
     rc = NGX_ERROR;
+    run_posted = false;
   } else {
     rc = ps_base_fetch::ps_base_fetch_handler(r);
   }
@@ -185,7 +187,7 @@ void NgxBaseFetch::ReadCallback(const ps_event_data& data) {
   ngx_connection_t* c = r->connection;
   ngx_http_finalize_request(r, rc);
 
-  if (!r->connection->error) {
+  if (run_posted) {
     // See http://forum.nginx.org/read.php?2,253006,253061
     ngx_http_run_posted_requests(c);
   }


### PR DESCRIPTION
We should not use r->connection after we finalize the request.

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/1100