### PR TITLE
Adjust our UA string to fix to make it compatible with fonts.g.c parsing on IE11.

### DIFF
--- a/src/ngx_fetch.cc
+++ b/src/ngx_fetch.cc
@@ -938,8 +938,8 @@ void NgxFetch::FixUserAgent() {
     user_agent += "NgxNativeFetcher";
   }
   GoogleString version = StrCat(
-      " ", kModPagespeedSubrequestUserAgent,
-      "/" MOD_PAGESPEED_VERSION_STRING "-" LASTCHANGE_STRING);
+      " (", kModPagespeedSubrequestUserAgent,
+      "/" MOD_PAGESPEED_VERSION_STRING "-" LASTCHANGE_STRING ")");
   if (!StringPiece(user_agent).ends_with(version)) {
     user_agent += version;
   }


### PR DESCRIPTION
Counterpart of:
https://github.com/pagespeed/mod_pagespeed/commit/f3639e84c0196a5f5151ff5e54ad57285db09b37