### PR TITLE
Fix a typo

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -637,7 +637,7 @@ typedef struct {
 typedef struct {
   // If pagespeed is configured in some server block but not this one our
   // per-request code will be invoked but server context will be null.  In those
-  // cases we neet to short circuit, not changing anything.  Currently our
+  // cases we need to short circuit, not changing anything.  Currently our
   // header filter, body filter, and content handler all do this, but if anyone
   // adds another way for nginx to give us a request to process we need to check
   // there as well.


### PR DESCRIPTION
`neet` → `need`