### PR TITLE
Allow varying on Accept header for ipro-for-browser.example.com

### DIFF
--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -704,6 +704,7 @@ http {
     pagespeed EnableFilters convert_to_webp_lossless;
     pagespeed EnableFilters in_place_optimize_for_browser;
     pagespeed InPlaceResourceOptimization on;
+    pagespeed AllowVaryOn "Accept";
     pagespeed FileCachePath "@@IPRO_CACHE@@";
   }
 


### PR DESCRIPTION
For backward compatibility, only allow varying on Accept header for ipro-for-browser.example.com