### PR TITLE
controller: don't fail tests when running in emacs

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -577,13 +577,18 @@ check test $(scrape_stat image_rewrite_total_original_bytes) -ge 10000
 # happens both before and after.
 start_test "Reload config"
 
+function find_exactly_once {
+  test $(grep -c "$1") -eq 1
+}
+
 function check_process_names() {
   if ! $USE_VALGRIND; then
     # There should be one babysitter and controller running.  Under valgrind
     # process labels are confused, so skip the check then.
 
-    check [ $(ps aux | grep -c 'nginx: pagespeed babysitte[r]') -eq 1 ]
-    check [ $(ps aux | grep -c 'nginx: pagespeed controlle[r]') -eq 1 ]
+    running=$(ps auxww | grep 'ngin[x]')
+    check_from "$running" find_exactly_once "nginx: pagespeed babysitter"
+    check_from "$running" find_exactly_once "nginx: pagespeed controller"
   fi
 }
 


### PR DESCRIPTION
Apparently, when running in emacs and piped into another command, ps limits
it's output to COLUMNS making check_process_names fail.  Telling ps to use
wide, wide output with 'ww' fixes this.

Additionally, use check_from so that if this test does fail we can debug
it better, seeing what grep was looking at.