### PR TITLE
Turn on C++11 for all compilers, not just clang.

### DIFF
--- a/config
+++ b/config
@@ -286,8 +286,6 @@ if [ -n "$ngx_module_link" ]; then
                            | sed "s/ngx_pagespeed_etag_filter//" \
                            | sed "s/ngx_http_range_header_filter_module/ngx_http_range_header_filter_module ngx_pagespeed_etag_filter/")
     else
-      # config.make is not executed for dynamic modules
-      CFLAGS="$CFLAGS -Wno-c++11-extensions"
       if [ "$position_aux" = "true" ] ; then
         ngx_module_type=HTTP_AUX_FILTER
         ngx_module_order=""
@@ -320,7 +318,7 @@ ngx_feature_libs="-lstdc++"
 ngx_feature_test="
 
 #if defined(__clang__) && defined(__GLIBCXX__)
-   // See https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html#abi.versioning 
+   // See https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html#abi.versioning
    // for a list of various values of __GLIBCXX__. Note that they're not monotonic
    // with respect to version numbers.
    #if __GLIBCXX__ == 20120322  || __GLIBCXX__ == 20120614

--- a/config.make
+++ b/config.make
@@ -1,7 +1,7 @@
-if [ -n "$NGX_CLANG_VER" ]; then
-  # Chromium headers assume clang is always in C++11 mode. Oblige it.
-  for ps_src_file in $PS_NGX_SRCS; do
-    ps_obj_file="$NGX_OBJS/addon/src/`basename $ps_src_file .cc`.o"
-    echo "$ps_obj_file : CFLAGS += --std=c++11" >> $NGX_MAKEFILE
-  done
-fi
+# Since nginx build system doesn't normally do C++, there is no CXXFLAGS for us
+# to touch, and compilers are understandably unhappy with --std=c++11 on C
+# files. Hence, we hack the makefile to add it for just our sources.
+for ps_src_file in $PS_NGX_SRCS; do
+  ps_obj_file="$NGX_OBJS/addon/src/`basename $ps_src_file .cc`.o"
+  echo "$ps_obj_file : CFLAGS += --std=c++11" >> $NGX_MAKEFILE
+done


### PR DESCRIPTION
Explain why we do it via config.make better.
Remove partial workaround for config.make not invoked for dynamic modules,
nginx dev fixes the root issue, and the workaround is insufficient anyway.