### PR TITLE
Fix request processing stalling on H/2 POSTS (as of nginx 1.9.14)

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -1786,11 +1786,13 @@ ngx_int_t ps_resource_handler(ngx_http_request_t* r,
 
   CHECK(!(html_rewrite && (ctx == NULL || ctx->html_rewrite == false)));
 
-  if (!html_rewrite &&
+  // TODO(oschaaf): Cover HTTP/2 in the system tests, especially IPRO and POSTS.
+  if ((!html_rewrite &&
       r->method != NGX_HTTP_GET &&
       r->method != NGX_HTTP_HEAD &&
-      r->method != NGX_HTTP_POST &&
-      response_category != RequestRouting::kCachePurge) {
+      (r->method == NGX_HTTP_POST &&
+        response_category  != RequestRouting::kBeacon) &&
+      response_category != RequestRouting::kCachePurge)) {
     return NGX_DECLINED;
   }
 


### PR DESCRIPTION
Nginx 1.9.14 introduces changes that seem to make us stall request
processing when we receive a POST request on HTTP/2. Debugging shows
we initiate the IPRO lookup, resume processing and things do not
proceed after that.

I suspect this is because NGINX now expects us to initiate reading of
the request body before we embark on an async wait operation in the
preaccess phase, but I yet have to prove that.

This change makes us only accept doing work for POST requests for
beacons in the preaccess phase. This path actually read the request
body and passes manual tests. I think is sufficient to tackle the
problem - and it looks like a change we should make anyway.

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/1175
