### PR TITLE
Sync top-level process scope options into RewriteDriverFactory::default_options

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -1120,7 +1120,7 @@ char* ps_merge_srv_conf(ngx_conf_t* cf, void* parent, void* child) {
 
   ps_main_conf_t* cfg_m = static_cast<ps_main_conf_t*>(
       ngx_http_conf_get_module_main_conf(cf, ngx_pagespeed));
-  cfg_m->driver_factory->set_main_conf(parent_cfg_s->options);
+  cfg_m->driver_factory->SetMainConf(parent_cfg_s->options);
   cfg_s->server_context = cfg_m->driver_factory->MakeNgxServerContext(
       "dummy_hostname", dummy_port);
 

--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -69,7 +69,6 @@ NgxRewriteDriverFactory::NgxRewriteDriverFactory(
     SystemThreadSystem* system_thread_system, StringPiece hostname, int port)
     : SystemRewriteDriverFactory(process_context, system_thread_system,
         NULL /* default shared memory runtime */, hostname, port),
-      main_conf_(NULL),
       threads_started_(false),
       ngx_message_handler_(
           new NgxMessageHandler(timer(), thread_system()->NewMutex())),
@@ -206,6 +205,12 @@ void NgxRewriteDriverFactory::StartThreads() {
   CHECK(ok) << "Unable to start scheduler thread";
   defer_cleanup(thread->MakeDeleter());
   threads_started_ = true;
+}
+
+void NgxRewriteDriverFactory::SetMainConf(NgxRewriteOptions* main_options) {
+  // Propagate process-scope options from the copy we had during nginx option
+  // parsing to our own.
+  default_options()->MergeOnlyProcessScopeOptions(*main_options);
 }
 
 void NgxRewriteDriverFactory::LoggingInit(

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -90,7 +90,7 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
     InitStats(statistics);
   }
 
-  void set_main_conf(NgxRewriteOptions* main_conf) {  main_conf_ = main_conf; }
+  void SetMainConf(NgxRewriteOptions* main_conf);
 
   void set_resolver(ngx_resolver_t* resolver) {
     resolver_ = resolver;
@@ -136,10 +136,6 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
 
  private:
   Timer* timer_;
-
-  // main_conf will have only options set in the main block.  It may be NULL,
-  // and we do not take ownership.
-  NgxRewriteOptions* main_conf_;
 
   bool threads_started_;
   NgxMessageHandler* ngx_message_handler_;


### PR DESCRIPTION
Needed for ImageMaxRewritesAtOnce to work with latest revisions.