### PR TITLE
Make ngx_pagespeed behave like mod_pagespeed with regard to flushing

### DIFF
--- a/src/ngx_base_fetch.h
+++ b/src/ngx_base_fetch.h
@@ -169,6 +169,7 @@ class NgxBaseFetch : public AsyncFetch {
   GoogleString buffer_;
   NgxServerContext* server_context_;
   const RewriteOptions* options_;
+  bool need_flush_;
   bool done_called_;
   bool last_buf_sent_;
   // How many active references there are to this fetch. Starts at two,

--- a/src/ngx_pagespeed.h
+++ b/src/ngx_pagespeed.h
@@ -52,7 +52,7 @@ class InPlaceResourceRecorder;
 // NGX_DECLINED immediately unless send_last_buf.
 ngx_int_t string_piece_to_buffer_chain(
     ngx_pool_t* pool, StringPiece sp,
-    ngx_chain_t** link_ptr, bool send_last_buf);
+    ngx_chain_t** link_ptr, bool send_last_buf, bool send_flush);
 
 StringPiece str_to_string_piece(ngx_str_t s);
 
@@ -109,6 +109,7 @@ typedef struct {
   // Location: headers that start with '/' without regarding X-Forwarded-Proto.
   bool location_field_set;
   bool psol_vary_accept_only;
+  bool follow_flushes;
 } ps_request_ctx_t;
 
 ps_request_ctx_t* ps_get_request_context(ngx_http_request_t* r);

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1309,6 +1309,12 @@ OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -O /dev/null -S $URL 2>&1)
 MATCHES=$(echo "$OUT" | grep -c "Vary: Accept-Encoding") || true
 check [ $MATCHES -eq 1 ]
 
+start_test Follow flushes can be turned off.
+echo "Check that FollowFlushes off outputs a single chunk"
+URL="http://noflush.example.com/mod_pagespeed_test/slow_flushing_html_response.php"
+check_flushing "curl -N --raw --silent --proxy $SECONDARY_HOSTNAME $URL" \
+  5.4 1
+
 start_test Shutting down.
 
 # Fire up some heavy load if ab is available to test a stressed shutdown

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -1522,7 +1522,45 @@ http {
     pagespeed InPlaceResourceOptimization on;
     pagespeed FileCachePath "@@FILE_CACHE@@";
   }
+  server {
+    pagespeed on;
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
+    server_name flush.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    pagespeed RewriteLevel PassThrough;
+    pagespeed RewriteDeadlinePerFlushMs 1;
 
+    location ~ \.php$ {
+      fastcgi_param SCRIPT_FILENAME $request_filename;
+      fastcgi_param QUERY_STRING $query_string;
+      fastcgi_param REQUEST_METHOD $request_method;
+      fastcgi_param CONTENT_TYPE $content_type;
+      fastcgi_param CONTENT_LENGTH $content_length;
+      fastcgi_pass 127.0.0.1:9000;
+      fastcgi_buffering off;
+    }
+  }
+  server {
+    pagespeed on;
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
+    server_name noflush.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    pagespeed RewriteLevel PassThrough;
+    pagespeed RewriteDeadlinePerFlushMs 1;
+    pagespeed FollowFlushes off;
+
+    location ~ \.php$ {
+      fastcgi_param SCRIPT_FILENAME $request_filename;
+      fastcgi_param QUERY_STRING $query_string;
+      fastcgi_param REQUEST_METHOD $request_method;
+      fastcgi_param CONTENT_TYPE $content_type;
+      fastcgi_param CONTENT_LENGTH $content_length;
+      fastcgi_pass 127.0.0.1:9000;
+      fastcgi_buffering off;
+    }
+  }
   server {
     listen @@PRIMARY_PORT@@;
     listen [::]:@@PRIMARY_PORT@@;


### PR DESCRIPTION
This change makes ngx_pagespeed listen to the FollowFlushes option.
When set to on (=default), ngx_pagespeed will forward incoming flushes
to ProxyFetch. When writing output, we'll now also set the flush flag on
the buffers we are about to send downstream.

Companion to mps PR https://github.com/pagespeed/mod_pagespeed/pull/1066