### PR TITLE
Fix for when there is only server-level configuration

### DIFF
--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -210,7 +210,9 @@ void NgxRewriteDriverFactory::StartThreads() {
 void NgxRewriteDriverFactory::SetMainConf(NgxRewriteOptions* main_options) {
   // Propagate process-scope options from the copy we had during nginx option
   // parsing to our own.
-  default_options()->MergeOnlyProcessScopeOptions(*main_options);
+  if (main_options != NULL) {
+    default_options()->MergeOnlyProcessScopeOptions(*main_options);
+  }
 }
 
 void NgxRewriteDriverFactory::LoggingInit(


### PR DESCRIPTION
When there is no top-level configuration but only server configuration,
we don't have main options to set and consider. This prevents
a NULL dereference in that case. (Later on we'll write out a message
about why we cannot startup with this configuration).