### PR TITLE
Check options->IsAllowed() before rewriting html.

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -2004,7 +2004,7 @@ ngx_int_t ps_resource_handler(ngx_http_request_t* r,
 
   }
 
-  if (html_rewrite) {
+  if (html_rewrite && options->IsAllowed(url.Spec())) {
     ps_create_base_fetch(url.Spec(), ctx, request_context,
                          request_headers.release(), kHtmlTransform, options);
     // Do not store driver in request_context, it's not safe.


### PR DESCRIPTION
While diagnosing a problem on the mps discussion [1] list I noticed that when using the following configuration ngx_pagespeed would still pass html through PageSpeed:

```
        pagespeed Disallow *;
```

This PR changes that, which seems on par with mod_pagespeed when I look at the code.

[1] https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/mod-pagespeed-discuss/ReOcIWbH7DE/RgQSIhUyBgAJ