### PR TITLE
special-responses: fix for hanging sometimes on special responses

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -288,7 +288,8 @@ ngx_int_t ps_base_fetch_handler(ngx_http_request_t* r) {
     if (!status_ok && (ctx->base_fetch->base_fetch_type() != kHtmlTransform
                        && ctx->base_fetch->base_fetch_type() != kIproLookup)) {
       ps_release_base_fetch(ctx);
-      return ngx_http_filter_finalize_request(r, NULL, status_code);
+      ngx_http_filter_finalize_request(r, NULL, status_code);
+      return NGX_DONE;
     }
 
     if (ctx->preserve_caching_headers != kDontPreserveHeaders) {

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1351,6 +1351,12 @@ URL="http://noflush.example.com/mod_pagespeed_test/slow_flushing_html_response.p
 check_flushing "curl -N --raw --silent --proxy $SECONDARY_HOSTNAME $URL" \
   5.4 1
 
+start_test Special responses from php are handled OK.
+URL="http://special-response.example.com/A.foo.css.pagespeed.cf.0.css"
+OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP -S --content-on-error $URL 2>&1) || true
+check_from "$OUT" fgrep -qi '404'
+check_from "$OUT" fgrep -q "PHP with a call to flush"
+
 start_test Shutting down.
 
 # Fire up some heavy load if ab is available to test a stressed shutdown
@@ -1434,6 +1440,7 @@ OUT=$(cat "$ERROR_LOG" \
     | grep -v "\\[warn\\].*Rewrite.*failed.*.pagespeed....0.foo.*" \
     | grep -v "\\[warn\\].*A.blue.css.*but cannot access the original.*" \
     | grep -v "\\[warn\\].*Adding function to sequence.*" \
+    | grep -v "\\[warn\\].*special-response.*foo.css.*but cannot access the original.*" \
     || true)
 
 check [ -z "$OUT" ]

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -1620,6 +1620,22 @@ http {
     pagespeed on;
     listen @@SECONDARY_PORT@@;
     listen [::]:@@SECONDARY_PORT@@;
+    server_name special-response.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    error_page 404 /mod_pagespeed_test/php_withflush.php;
+    location ~ \.php$ {
+      fastcgi_param SCRIPT_FILENAME $request_filename;
+      fastcgi_param QUERY_STRING $query_string;
+      fastcgi_param REQUEST_METHOD $request_method;
+      fastcgi_param CONTENT_TYPE $content_type;
+      fastcgi_param CONTENT_LENGTH $content_length;
+      fastcgi_pass 127.0.0.1:9000;
+    }
+  }
+  server {
+    pagespeed on;
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
     server_name debug-filters.example.com;
     pagespeed FileCachePath "@@FILE_CACHE@@";
     pagespeed RewriteLevel PassThrough;


### PR DESCRIPTION
After calling ngx_http_filter_finalize_request return NGX_DONE
as we are still in pre-access phase. This bug shows up when the
"special" response is generated from, for example, php as opposed
to a static file.

Second part of the fix for
https://github.com/pagespeed/ngx_pagespeed/issues/1146