### PR TITLE
Allow processing of script variablies in more options

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -884,14 +884,14 @@ char* ps_configure(ngx_conf_t* cf,
         cfg_m->driver_factory->thread_system());
   }
 
-  bool process_script_variables = dynamic_cast<NgxRewriteDriverFactory*>(
-      cfg_m->driver_factory)->process_script_variables();
-
-  if (process_script_variables) {
+  ProcessScriptVariablesMode script_mode =
+      dynamic_cast<NgxRewriteDriverFactory*>(cfg_m->driver_factory)
+          ->process_script_variables();
+  if (script_mode != ProcessScriptVariablesMode::kOff) {
     // To be able to use '$', we map '$ps_dollar' to '$' via a script variable.
     ngx_str_t name = ngx_string("ps_dollar");
-    ngx_http_variable_t* var = ngx_http_add_variable(
-        cf, &name, NGX_HTTP_VAR_CHANGEABLE);
+    ngx_http_variable_t* var =
+        ngx_http_add_variable(cf, &name, NGX_HTTP_VAR_CHANGEABLE);
 
     if (var == NULL) {
       return const_cast<char*>(
@@ -902,7 +902,7 @@ char* ps_configure(ngx_conf_t* cf,
 
   const char* status = (*options)->ParseAndSetOptions(
       args, n_args, cf->pool, handler, cfg_m->driver_factory, option_scope, cf,
-      process_script_variables);
+      script_mode);
 
   // nginx expects us to return a string literal but doesn't mark it const.
   return const_cast<char*>(status);

--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -82,7 +82,7 @@ NgxRewriteDriverFactory::NgxRewriteDriverFactory(
       ngx_shared_circular_buffer_(NULL),
       hostname_(hostname.as_string()),
       port_(port),
-      process_script_variables_(false),
+      process_script_variables_mode_(ProcessScriptVariablesMode::kOff),
       process_script_variables_set_(false),
       shut_down_(false) {
   InitializeDefaultOptions();

--- a/src/ngx_rewrite_driver_factory.h
+++ b/src/ngx_rewrite_driver_factory.h
@@ -48,6 +48,12 @@ class SlowWorker;
 class Statistics;
 class SystemThreadSystem;
 
+enum ProcessScriptVariablesMode {
+  kOff,
+  kLegacyRestricted,
+  kAll
+};
+
 class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
  public:
   // We take ownership of the thread system.
@@ -112,8 +118,8 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
   void set_native_fetcher_max_keepalive_requests(int x) {
     native_fetcher_max_keepalive_requests_ = x;
   }
-  bool process_script_variables() {
-    return process_script_variables_;
+  ProcessScriptVariablesMode process_script_variables() {
+    return process_script_variables_mode_;
   }
 
   void LoggingInit(ngx_log_t* log, bool may_install_crash_handler);
@@ -122,9 +128,9 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
 
   virtual void SetCircularBuffer(SharedCircularBuffer* buffer);
 
-  bool SetProcessScriptVariables(bool process_script_variables) {
+  bool SetProcessScriptVariables(ProcessScriptVariablesMode mode) {
     if (!process_script_variables_set_) {
-      process_script_variables_ = process_script_variables;
+      process_script_variables_mode_ = mode;
       process_script_variables_set_ = true;
       return true;
     }
@@ -158,7 +164,7 @@ class NgxRewriteDriverFactory : public SystemRewriteDriverFactory {
 
   GoogleString hostname_;
   int port_;
-  bool process_script_variables_;
+  ProcessScriptVariablesMode process_script_variables_mode_;
   bool process_script_variables_set_;
   bool shut_down_;
 

--- a/src/ngx_rewrite_options.h
+++ b/src/ngx_rewrite_options.h
@@ -29,6 +29,8 @@ extern "C" {
 
 #include <vector>
 
+#include "ngx_rewrite_driver_factory.h"
+
 #include "net/instaweb/rewriter/public/rewrite_options.h"
 #include "pagespeed/kernel/base/message_handler.h"
 #include "pagespeed/kernel/base/ref_counted_ptr.h"
@@ -131,7 +133,7 @@ class NgxRewriteOptions : public SystemRewriteOptions {
   const char* ParseAndSetOptions(
       StringPiece* args, int n_args, ngx_pool_t* pool, MessageHandler* handler,
       NgxRewriteDriverFactory* driver_factory, OptionScope scope,
-      ngx_conf_t* cf, bool compile_scripts);
+      ngx_conf_t* cf, ProcessScriptVariablesMode script_mode);
   bool ExecuteScriptVariables(
       ngx_http_request_t* r, MessageHandler* handler,
       NgxRewriteDriverFactory* driver_factory);

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -30,7 +30,7 @@ http {
   proxy_cache_path "@@PROXY_CACHE@@"  levels=1:2   keys_zone=htmlcache:60m inactive=90m  max_size=50m;
   proxy_temp_path "@@TMP_PROXY_CACHE@@";
 
-  pagespeed ProcessScriptVariables on;
+  pagespeed ProcessScriptVariables all;
   pagespeed StatisticsPath /ngx_pagespeed_statistics;
   pagespeed GlobalStatisticsPath /ngx_pagespeed_global_statistics;
   pagespeed ConsolePath /pagespeed_console;
@@ -1905,7 +1905,9 @@ http {
     }
 
     location /mod_pagespeed_test/ipro/instant/deadline/ {
-      pagespeed InPlaceRewriteDeadlineMs -1;
+      set $ps_deadline -1;
+      pagespeed ImageRecompressionQuality $ps_deadline;
+      pagespeed InPlaceRewriteDeadlineMs $ps_deadline;
     }
 
     # Test to make sure that user-authenticated resources do not get cached and
@@ -1953,9 +1955,10 @@ http {
     pagespeed FetchHttps enable;
     location /mod_pagespeed_test/https_fetch/ {
       pagespeed DisableFilters inline_images;
+      set $ps_gstatic "https://www.gstatic.com/psa/static";
       pagespeed MapProxyDomain
           http://localhost:@@PRIMARY_PORT@@/https_gstatic_dot_com
-          https://www.gstatic.com/psa/static;
+          $ps_gstatic;
     }
 
     location /mod_pagespeed_test/strip_subresource_hints/default/ {
@@ -2002,7 +2005,6 @@ http {
       "@@SERVER_ROOT@@/mod_pagespeed_test/load_from_file/file_dir/httponly/";
     pagespeed LoadFromFileRuleMatch Disallow \.ssp.css$ps_dollar;
     pagespeed LoadFromFileRuleMatch Allow exception\.ssp\.css$ps_dollar;
-
     #charset koi8-r;
 
     #access_log  logs/host.access.log  main;


### PR DESCRIPTION
All directory- and process- scoped options are allowed with this
change, when "ProcessScriptVariables all" is specified.

Option list compiled from:
https://docs.google.com/spreadsheets/d/1qJSUZqd2Te-4SDtm1Av6u-AckNv_oHEp1qdaUjNqZoM/edit#gid=0