### PR TITLE
Separate option for the critical image beacon url

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -1763,13 +1763,17 @@ RequestRouting::Response ps_route_request(ngx_http_request_t* r) {
   }
 
   const GoogleString* beacon_url;
+  const GoogleString* critical_images_beacon_url;
   if (ps_is_https(r)) {
     beacon_url = &(global_options->beacon_url().https);
+    critical_images_beacon_url = &(global_options->critical_images_beacon_url().https);
   } else {
     beacon_url = &(global_options->beacon_url().http);
+    critical_images_beacon_url = &(global_options->critical_images_beacon_url().http);
   }
 
-  if (url.PathSansQuery() == StringPiece(*beacon_url)) {
+  if (url.PathSansQuery() == StringPiece(*beacon_url) ||
+     url.PathSansQuery() == StringPiece(*critical_images_beacon_url)) {
     return RequestRouting::kBeacon;
   }
 

--- a/src/ngx_rewrite_driver_factory.cc
+++ b/src/ngx_rewrite_driver_factory.cc
@@ -87,6 +87,7 @@ NgxRewriteDriverFactory::NgxRewriteDriverFactory(
       shut_down_(false) {
   InitializeDefaultOptions();
   default_options()->set_beacon_url("/ngx_pagespeed_beacon");
+  default_options()->set_critical_images_beacon_url("/ngx_pagespeed_beacon");
   SystemRewriteOptions* system_options = dynamic_cast<SystemRewriteOptions*>(
       default_options());
   system_options->set_file_cache_clean_inode_limit(500000);

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -319,7 +319,8 @@ if [ ! -e "$SYSTEM_TEST_FILE" ] ; then
 fi
 
 PSA_JS_LIBRARY_URL_PREFIX="pagespeed_custom_static"
-BEACON_HANDLER="ngx_pagespeed_beacon"
+BEACON_HANDLER="nps-timing-beacon"
+CRITICAL_IMAGES_BEACON_HANDLER="nps-image-beacon"
 STATISTICS_HANDLER="ngx_pagespeed_statistics"
 GLOBAL_STATISTICS_HANDLER="ngx_pagespeed_global_statistics"
 MESSAGES_HANDLER="ngx_pagespeed_message"

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -40,6 +40,9 @@ http {
 
   pagespeed StaticAssetPrefix /pagespeed_custom_static/;
 
+  pagespeed BeaconUrl /nps-timing-beacon;
+  pagespeed CriticalImagesBeaconUrl /nps-image-beacon;
+
   pagespeed MessageBufferSize 200000;
   # Increase the default fetcher timeout to resolve sporadic flakeyness when
   # the native fetcher uses 8.8.8.8 to resolve.


### PR DESCRIPTION
Should go in together with the following MPS change:
https://github.com/pagespeed/mod_pagespeed/pull/1375
