### PR TITLE
Make NgxMessageHandler::FileMessage() add data into internal buffer as well

### DIFF
--- a/src/ngx_message_handler.cc
+++ b/src/ngx_message_handler.cc
@@ -97,7 +97,6 @@ void NgxMessageHandler::MessageSImpl(MessageType type,
   } else {
     GoogleMessageHandler::MessageSImpl(type, message);
   }
-  // Prepare a log message for the SharedCircularBuffer only.
   AddMessageToBuffer(type, message);
 }
 
@@ -111,6 +110,7 @@ void NgxMessageHandler::FileMessageSImpl(
   } else {
     GoogleMessageHandler::FileMessageSImpl(type, file, line, message);
   }
+  AddMessageToBuffer(type, file, line, message);
 }
 
 }  // namespace net_instaweb


### PR DESCRIPTION
Nginx side of a change which adds `SystemMessageBuffer::AddMessageToBuffer(type, file, line, message)` and fixes similar bug in `ApacheMessageHandler`.