### PR TITLE
allow sloppy exit

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1433,6 +1433,7 @@ OUT=$(cat "$ERROR_LOG" \
     | grep -v "\\[warn\\].*Controller process .* exited with status code.*" \
     | grep -v "\\[warn\\].*Rewrite.*failed.*.pagespeed....0.foo.*" \
     | grep -v "\\[warn\\].*A.blue.css.*but cannot access the original.*" \
+    | grep -v "\\[warn\\].*Adding function to sequence.*" \
     || true)
 
 check [ -z "$OUT" ]

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -1880,6 +1880,11 @@ http {
         "http://$host:@@PRIMARY_PORT@@/mod_pagespeed_test/ipro/instant/"
         "@@SERVER_ROOT@@/mod_pagespeed_test/ipro/instant/";
 
+    location /mod_pagespeed_test/public/ {
+      add_header "Cache-Control" "public, max-age=600";
+      pagespeed PreserveUrlRelativity off;
+    }
+
     pagespeed EnableFilters remove_comments;
 
     # Test LoadFromFile mapping by mapping one dir to another.


### PR DESCRIPTION
allow 'adding function to sequence' warnings on shutdown, without breaking the nginx debug tests