### PR TITLE
tests: check flushing changed its arguments

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1366,9 +1366,7 @@ check [ $MATCHES -eq 1 ]
 
 start_test Follow flushes can be turned off.
 echo "Check that FollowFlushes off outputs a single chunk"
-URL="http://noflush.example.com/mod_pagespeed_test/slow_flushing_html_response.php"
-check_flushing "curl -N --raw --silent --proxy $SECONDARY_HOSTNAME $URL" \
-  5.4 1
+check_flushing 5.4 1
 
 start_test Special responses from php are handled OK.
 URL="http://special-response.example.com/A.foo.css.pagespeed.cf.0.css"


### PR DESCRIPTION
I have a parallel change in PSOL that refactors out the duplication here and moves the `curl` setup into `check_flushes`.