### PR TITLE
install: fix quoting

### DIFF
--- a/scripts/build_ngx_pagespeed.sh
+++ b/scripts/build_ngx_pagespeed.sh
@@ -491,7 +491,7 @@ Not deleting $directory; name is suspiciously short.  Something is wrong."
     if [ -n "$additional_configure_args" ]; then
       # Split additional_configure_args respecting any internal quotation.
       # Otherwise things like --with-cc-opt='-foo -bar' won't work.
-      eval additional_configure_args=($additional_configure_args)
+      eval additional_configure_args=("$additional_configure_args")
       configure=("${configure[@]}" "${additional_configure_args[@]}")
     fi
     echo "About to configure nginx with:"


### PR DESCRIPTION
We want to parse `$additional_configure_arg`s into an array the way the
shell would, which we're using `eval` for.  But because we were missing
quotes whitespace was being stripped.  Basically:

    $ function lines() { for x in "$@"; do echo "$x"; done; }

    $ lines a "b   c" d
    a
    b   c
    d

    $ a='a "b   c" d'
    $ eval e=($a)
    $ eval f=("$a")

    $ lines "${e[@]}"
    a
    b c
    d

    $ lines "${f[@]}"
    a
    b   c
    d

We were doing this like `e` when we should have been doing it like `f`.