### PR TITLE
testing: check_flushing needs to know the host name

### DIFF
--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1366,7 +1366,7 @@ check [ $MATCHES -eq 1 ]
 
 start_test Follow flushes can be turned off.
 echo "Check that FollowFlushes off outputs a single chunk"
-check_flushing 5.4 1
+check_flushing noflush 5.4 1
 
 start_test Special responses from php are handled OK.
 URL="http://special-response.example.com/A.foo.css.pagespeed.cf.0.css"


### PR DESCRIPTION
Followup to cd004c6d0c1389602f7493d840b3226ca47313a4