### PR TITLE
base fetch: stop ignoring the argument to HandleDone

### DIFF
--- a/src/ngx_base_fetch.h
+++ b/src/ngx_base_fetch.h
@@ -171,6 +171,7 @@ class NgxBaseFetch : public AsyncFetch {
   const RewriteOptions* options_;
   bool need_flush_;
   bool done_called_;
+  bool successful_;
   bool last_buf_sent_;
   // How many active references there are to this fetch. Starts at two,
   // decremented once when Done() is called and once when Detach() is called.


### PR DESCRIPTION
`HandleDone`, all the way back to its introduction in b9fff219, has ignored its argument, acting as if it was always being passed `success=true`.  This mostly was not a problem, but it was recently causing flakes in the `resource_content_type_html.sh` system test when run under valgrind.  The problem was that the deadline alarm would fire, which would jump the request handling to `SendFallbackResponse`, which would see the (invalid in this situation) html content type and start passing `success=false up` the callback chain.  `NgxBaseFetch:HandleDone` would receive success=false, ignore it, and keep the headers that should have been dropped.

With this change, after `HandleDone` is called with `success=false` and a successful status code we ignore any headers or body from PSOL and send out a 404 instead.

Before this change, under valgrind, the following loop got 5 flakes in 133 runs:

```
while true; do
  curl -sS -v -D- \
    http://localhost:8050/mod_pagespeed_example/index.html.pagespeed.jm.0.foo
done
```

With this change, it gets 0 flakes in 10000 runs.

Additionally, running with `test_instant_fetch_rewrite_deadline=true` would previously always elicit the flake in ngx_pagespeed, and now it doesn't.