### PR TITLE
test: run_tests.sh should just assume 8050 and 8051

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ install:
   - sudo make install
 script:
   - echo "build successful"
-  - cd ~/ngxpagespeed
-  - sudo ./test/run_tests.sh $HOME/mod_pagespeed $HOME/nginx-branches-default/objs/nginx
+  - echo "cd ~/ngxpagespeed"
+  - echo "sudo ./test/run_tests.sh $HOME/mod_pagespeed $HOME/nginx-branches-default/objs/nginx"
 sudo: required
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,8 @@ install:
   - sudo make install
 script:
   - echo "build successful"
-  - echo "cd ~/ngxpagespeed"
-  - echo "sudo ./test/run_tests.sh 8050 8051 $HOME/mod_pagespeed/src $HOME/nginx-branches-default/objs selfsigned.modpagespeed.com"
-  - echo "sudo ./test/run_tests.sh 8050 8051 $HOME/mod_pagespeed $HOME/nginx-branches-default/objs/nginx selfsigned.modpagespeed.com"
+  - cd ~/ngxpagespeed
+  - sudo ./test/run_tests.sh $HOME/mod_pagespeed $HOME/nginx-branches-default/objs/nginx
 sudo: required
 compiler:
   - gcc

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -1184,7 +1184,7 @@ OUT=$($WGET_DUMP --header=Host:response-header-disable.example.com $URL)
 check_not_from "$OUT" egrep -qi 'addInstrumentationInit'
 
 # TODO(jmaessen, jefftk): Port proxying tests, which rely on pointing a
-# MapProxyDomain construct at a static server.  Perhaps localhost:8050 will
+# MapProxyDomain construct at a static server.  Perhaps $HOSTNAME will
 # serve, but the tests need to use different urls then.  For mod_pagespeed these
 # tests immediately precede the "scrape_secondary_stat" definition in
 # system_test.sh.

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -232,7 +232,7 @@ http {
 
     # Block 6: Location block with proxy_cache directives.
     location /mod_pagespeed_test/cachable_rewritten_html/ {
-      # 1: Upstream PageSpeed server is running at localhost:8050.
+      # 1: Upstream PageSpeed server is running at localhost:@@PRIMARY_PORT@@.
       proxy_pass http://localhost:@@PRIMARY_PORT@@;
       # 2: Use htmlcache as the zone for caching.
       proxy_cache htmlcache;

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -24,6 +24,11 @@
 #
 # Usage:
 #   ./run_tests.sh /path/to/mod_pagespeed /path/to/nginx/binary
+#
+# By default the test script uses several ports.  If you have a port conflict
+# and need to override one you can do that by setting the relevant environment
+# variable.  For example:
+#   PRIMARY_PORT=1234 ./run_tests.sh /.../mod_pagespeed /.../nginx/binary
 
 # Normally we test only with the native fetcher off.  Set
 # TEST_NATIVE_FETCHER=true to also test the native fetcher, set
@@ -48,11 +53,11 @@ fi
 MOD_PAGESPEED_DIR="$1"
 NGINX_EXECUTABLE="$2"
 
-PRIMARY_PORT=8050
-SECONDARY_PORT=8051
-CONTROLLER_PORT=8053
-RCPORT=9991
-PAGESPEED_TEST_HOST=selfsigned.modpagespeed.com
+: ${PRIMARY_PORT:=8050}
+: ${SECONDARY_PORT:=8051}
+: ${CONTROLLER_PORT:=8053}
+: ${RCPORT:=9991}
+: ${PAGESPEED_TEST_HOST:=selfsigned.modpagespeed.com}
 
 this_dir="$( cd $(dirname "$0") && pwd)"
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -23,12 +23,7 @@
 # Exits with status 2 if command line args are wrong.
 #
 # Usage:
-#   ./run_tests.sh primary_port secondary_port mod_pagespeed_dir ngx_binary
-#   pagespeed_test_host
-# Example:
-#   ./run_tests.sh 8050 8051 /path/to/mod_pagespeed /path/to/nginx/binary
-#   selfsigned.modpagespeed.com
-#
+#   ./run_tests.sh /path/to/mod_pagespeed /path/to/nginx/binary
 
 # Normally we test only with the native fetcher off.  Set
 # TEST_NATIVE_FETCHER=true to also test the native fetcher, set
@@ -45,19 +40,19 @@ RUN_TESTS=${RUN_TESTS:-true}
 # true.
 USE_VALGRIND=${USE_VALGRIND:-false}
 
-if [ "$#" -ne 5 ] ; then
-  echo "Usage: $0 primary_port secondary_port mod_pagespeed_dir"
-  echo "  nginx_executable"
+if [ "$#" -ne 2 ] ; then
+  echo "Usage: $0 mod_pagespeed_dir nginx_executable"
   exit 2
 fi
 
-PRIMARY_PORT="$1"
-SECONDARY_PORT="$2"
-MOD_PAGESPEED_DIR="$3"
-NGINX_EXECUTABLE="$4"
-PAGESPEED_TEST_HOST="$5"
+MOD_PAGESPEED_DIR="$1"
+NGINX_EXECUTABLE="$2"
+
+PRIMARY_PORT=8050
+SECONDARY_PORT=8051
 CONTROLLER_PORT=8053
 RCPORT=9991
+PAGESPEED_TEST_HOST=selfsigned.modpagespeed.com
 
 this_dir="$( cd $(dirname "$0") && pwd)"
 


### PR DESCRIPTION
Right now run_tests.sh assumes it has 8053 and 9991 without causing any
problems.  Start assuming we have 8050 and 8051 as well instead of
requiring people to pass them in.