### PR TITLE
config: use Release binaries when building with --with-debug if that's all that's available

### DIFF
--- a/config
+++ b/config
@@ -77,6 +77,8 @@ fi
 
 if [ "$NGX_DEBUG" = "YES" ]; then
   buildtype=Debug
+  # If we're using a psol tarball that doesn't contain Debug/ (which is the case
+  # from 1.12 onward) then this will be overriden to buildtype=Release below.
 else
   buildtype=Release
 fi
@@ -144,6 +146,9 @@ if [ "$psol_binary" = "unset" ] ; then
     psol_binary="\
         $mod_pagespeed_dir/pagespeed/automatic/pagespeed_automatic.a"
   else
+    if ! [ -d "$ngx_addon_dir/psol/lib/$buildtype" ]; then
+      buildtype=Release
+    fi
     psol_library_dir="$ngx_addon_dir/psol/lib/$buildtype/$os_name/$arch_name"
     psol_binary="$psol_library_dir/pagespeed_automatic.a"
   fi

--- a/config
+++ b/config
@@ -147,6 +147,19 @@ if [ "$psol_binary" = "unset" ] ; then
         $mod_pagespeed_dir/pagespeed/automatic/pagespeed_automatic.a"
   else
     if ! [ -d "$ngx_addon_dir/psol/lib/$buildtype" ]; then
+      echo "
+You have set --with-debug for building nginx, but precompiled Debug binaries for
+PSOL, which ngx_pagespeed depends on, aren't available.  You can either build
+PSOL from source with debugging information, or you can just go ahead and use
+the Release binaries."
+      echo -n "
+Use the available Release binaries?"
+      read -p " [Y/n] " yn
+      if [[ "$yn" == N* || "$yn" == n* ]]; then
+        echo "Cancelled."
+        exit 0
+      fi
+
       buildtype=Release
     fi
     psol_library_dir="$ngx_addon_dir/psol/lib/$buildtype/$os_name/$arch_name"

--- a/config
+++ b/config
@@ -149,15 +149,15 @@ if [ "$psol_binary" = "unset" ] ; then
     if ! [ -d "$ngx_addon_dir/psol/lib/$buildtype" ]; then
       echo "
 You have set --with-debug for building nginx, but precompiled Debug binaries for
-PSOL, which ngx_pagespeed depends on, aren't available.  You can either build
-PSOL from source with debugging information, or you can just go ahead and use
-the Release binaries."
+PSOL, which ngx_pagespeed depends on, aren't available.  If you're trying to
+debug PSOL you need to build it from source.  If you just want to run nginx with
+debug-level logging you can use the Release binaries."
       echo -n "
 Use the available Release binaries?"
       read -p " [Y/n] " yn
       if [[ "$yn" == N* || "$yn" == n* ]]; then
         echo "Cancelled."
-        exit 0
+        exit 1
       fi
 
       buildtype=Release


### PR DESCRIPTION
Fixes #1333 