### PR TITLE
installer: allow --dynamic-module to be used with tags

### DIFF
--- a/scripts/build_ngx_pagespeed.sh
+++ b/scripts/build_ngx_pagespeed.sh
@@ -420,11 +420,20 @@ function build_ngx_pagespeed() {
 
   if "$DYNAMIC_MODULE"; then
     # Check that ngx_pagespeed and nginx are recent enough to support dynamic
-    # modules.
-    if version_older_than "$NPS_VERSION" "1.10.33.5"; then
-      fail "
+    # modules.  Unfortunately NPS_VERSION might be a tag, in which case we don't
+    # know.  If it's not a numeric version number, then assume it's recent
+    # enough and if it's not they'll get an ugly compilation error later.
+    # Luckily 1.10.33.5 was a while ago now.
+    #
+    # I'd like to use bash regexps here, but they changed syntax between v3 and
+    # v4 (quotes moved from mandatory to optional to prohibited) so I can't use
+    # them.
+    if echo "$NPS_VERSION" | grep -q "^[0-9.]*$"; then
+      if version_older_than "$NPS_VERSION" "1.10.33.5"; then
+        fail "
 You're trying to build ngx_pagespeed $NPS_VERSION as a dynamic module, but
 ngx_pagespeed didn't add support for dynamic modules until 1.10.33.5."
+      fi
     fi
 
     if [ ! -z "NGINX_VERSION" ]; then

--- a/scripts/build_ngx_pagespeed.sh
+++ b/scripts/build_ngx_pagespeed.sh
@@ -425,15 +425,13 @@ function build_ngx_pagespeed() {
     # enough and if it's not they'll get an ugly compilation error later.
     # Luckily 1.10.33.5 was a while ago now.
     #
-    # I'd like to use bash regexps here, but they changed syntax between v3 and
-    # v4 (quotes moved from mandatory to optional to prohibited) so I can't use
-    # them.
-    if echo "$NPS_VERSION" | grep -q "^[0-9.]*$"; then
-      if version_older_than "$NPS_VERSION" "1.10.33.5"; then
-        fail "
+    # I'd like to use =~ here, but they changed syntax between v3 and v4 (quotes
+    # moved from mandatory to optional to prohibited).
+    if [[ "${NPS_VERSION#*[^0-9.]}" = "$NPS_VERSION" ]] &&
+         version_older_than "$NPS_VERSION" "1.10.33.5"; then
+      fail "
 You're trying to build ngx_pagespeed $NPS_VERSION as a dynamic module, but
 ngx_pagespeed didn't add support for dynamic modules until 1.10.33.5."
-      fi
     fi
 
     if [ ! -z "NGINX_VERSION" ]; then


### PR DESCRIPTION
A user-friendly check with dynamic module building tries to warn people early if the version of ngx_pagespeed they're building is too old to be compiled as a dynamic module, but this can't work with tags.  If we're given something other than a numeric version number, don't try to perform this check.

Fixes https://github.com/pagespeed/mod_pagespeed/issues/1443