### PR TITLE
licensing: correct bash license comments

### DIFF
--- a/scripts/build_ngx_pagespeed.sh
+++ b/scripts/build_ngx_pagespeed.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 function usage() {
   echo "

--- a/scripts/format_binary_url.sh
+++ b/scripts/format_binary_url.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -e
 set -u

--- a/scripts/pagespeed_libraries_generator.sh
+++ b/scripts/pagespeed_libraries_generator.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2013 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Converts pagespeed_libraries.conf from Apache-format to Nginx-format,
 # supporting the canonicalize_javascript_libraries filter.
 # Inspired by https://github.com/pagespeed/ngx_pagespeed/issues/532


### PR DESCRIPTION
A few bash files were missing license comments