### PR TITLE
devel: simplify ngx_pagespeed development flow

### DIFF
--- a/scripts/build_ngx_pagespeed.sh
+++ b/scripts/build_ngx_pagespeed.sh
@@ -767,25 +767,13 @@ Not deleting $directory; name is suspiciously short.  Something is wrong."
     if "$DEVEL"; then
       run make install
 
-      status "Nginx installed with ngx_pagespeed, and set up for testing."
-      # TODO(jefftk): pull these out into separate scripts.
-      echo "To run tests, pick a pair of ports like 8050 and 8051 and run:"
+      status "Nginx installed with ngx_pagespeed, and set up for development."
+      echo "To run tests:"
       echo "  cd $nps_module_dir"
-      echo "  RUN_TESTS=true \\"
-      echo "  USE_VALGRIND=false \\"
-      echo "  TEST_NATIVE_FETCHER=false \\"
-      echo "  TEST_SERF_FETCHER=true \\"
-      echo "  test/run_tests.sh \\"
-      echo "    $MOD_PAGESPEED_DIR \\"
-      echo "    $install_dir/nginx/sbin/nginx"
+      echo "  test/run_tests.sh"
       echo
       echo "To rebuild after changes:"
-      echo "  First, if you change things in PSOL or update it:"
-      echo "    cd $MOD_PAGESPEED_DIR/devel"
-      echo "    make apache_debug_psol"
-      echo "  Then, whether or not you updated PSOL, rebuild nginx:"
-      echo "    cd $install_dir/nginx"
-      echo "    make && make install"
+      echo "  scripts/rebuild.sh"
     else
       continue_or_exit "Install nginx?"
       run sudo make install

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: scripts/rebuild.sh
+#
+# After building with "scripts/build_ngx_pagespeed.sh --devel", if you make
+# changes to ngx_pagespeed you'll need to rebuild it.  The underlying commands
+# aren't complicated, but it's faster to work if it's automated.
+
+set -e  # exit script if any command returns an error
+set -u  # exit the script if any variable is uninitialized
+
+this_dir="$(dirname $0)"
+cd "$this_dir/.."
+nps_dir="$PWD"
+
+cd "$nps_dir/testing-dependencies/mod_pagespeed/devel"
+make apache_debug_psol
+
+cd "$nps_dir/testing-dependencies/nginx/"
+make
+make install

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -23,7 +23,14 @@
 # Exits with status 2 if command line args are wrong.
 #
 # Usage:
+#   ./run_tests.sh
+# Or:
 #   ./run_tests.sh /path/to/mod_pagespeed /path/to/nginx/binary
+#
+# If you built ngx_pagespeed with "scripts/build_ngx_pagespeed.sh --devel" then
+# you don't need to pass any arguments to run_tests.sh.  Otherwise, you'll need
+# to tell it where to find a mod_pagespeed checkout (for example html files etc)
+# and the nginx binary to test.
 #
 # By default the test script uses several ports.  If you have a port conflict
 # and need to override one you can do that by setting the relevant environment
@@ -45,13 +52,16 @@ RUN_TESTS=${RUN_TESTS:-true}
 # true.
 USE_VALGRIND=${USE_VALGRIND:-false}
 
-if [ "$#" -ne 2 ] ; then
-  echo "Usage: $0 mod_pagespeed_dir nginx_executable"
+if [ "$#" -eq 0 ]; then
+  MOD_PAGESPEED_DIR="testing-dependencies/mod_pagespeed/"
+  NGINX_EXECUTABLE="nginx/sbin/nginx"
+elif [ "$#" -eq 2 ]; then
+  MOD_PAGESPEED_DIR="$1"
+  NGINX_EXECUTABLE="$2"
+else
+  echo "Usage: $0 [mod_pagespeed_dir nginx_executable]"
   exit 2
 fi
-
-MOD_PAGESPEED_DIR="$1"
-NGINX_EXECUTABLE="$2"
 
 : ${PRIMARY_PORT:=8050}
 : ${SECONDARY_PORT:=8051}


### PR DESCRIPTION
* provide scripts/rebuild.sh so you don't have to run make commands in
  two directories
* make test/run_tests.sh able to run with no arguments by setting good defaults.