### PR TITLE
standby: add standby mode

### DIFF
--- a/src/ngx_rewrite_options.cc
+++ b/src/ngx_rewrite_options.cc
@@ -192,15 +192,18 @@ RewriteOptions::OptionScope NgxRewriteOptions::GetOptionScope(
 
 RewriteOptions::OptionSettingResult NgxRewriteOptions::ParseAndSetOptions0(
     StringPiece directive, GoogleString* msg, MessageHandler* handler) {
-  if (IsDirective(directive, "on")) {
-    set_enabled(RewriteOptions::kEnabledOn);
-  } else if (IsDirective(directive, "off")) {
-    set_enabled(RewriteOptions::kEnabledOff);
-  } else if (IsDirective(directive, "unplugged")) {
-    set_enabled(RewriteOptions::kEnabledUnplugged);
-  } else {
+  EnabledEnum enabled;
+  if (!ParseFromString(directive, &enabled)) {
     return RewriteOptions::kOptionNameUnknown;
   }
+  if (enabled == RewriteOptions::kEnabledOff) {
+    // In ngx_pagespeed, for historical reasons, we treat "off" as "unplugged".
+    // Also, "off" is deprecated and people should be using "standby" or
+    // "unplugged" now depending on which sense they want.  See comment on
+    // RewriteOptions::EnabledEnum.
+    enabled = RewriteOptions::kEnabledUnplugged;
+  }
+  set_enabled(enabled);
   return RewriteOptions::kOptionOk;
 }
 

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -132,6 +132,42 @@ http {
       "@@SERVER_ROOT@@/mod_pagespeed_example/styles/";
   }
 
+  server {
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
+    server_name pagespeed-off.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    pagespeed off;
+    pagespeed EnableFilters collapse_whitespace;
+  }
+
+  server {
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
+    server_name pagespeed-on.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    pagespeed on;
+    pagespeed EnableFilters collapse_whitespace;
+  }
+
+  server {
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
+    server_name pagespeed-standby.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    pagespeed standby;
+    pagespeed EnableFilters collapse_whitespace;
+  }
+
+  server {
+    listen @@SECONDARY_PORT@@;
+    listen [::]:@@SECONDARY_PORT@@;
+    server_name pagespeed-unplugged.example.com;
+    pagespeed FileCachePath "@@FILE_CACHE@@";
+    pagespeed unplugged;
+    pagespeed EnableFilters collapse_whitespace;
+  }
+
   pagespeed UseNativeFetcher "@@NATIVE_FETCHER@@";
   @@RESOLVER@@
 


### PR DESCRIPTION
Add standby mode for ngx_pagespeed, equivalent to "off" in mod_pagespeed.

With this change "off" is deprecated, and people should use "unplugged" instead.

See also: https://github.com/pagespeed/mod_pagespeed/pull/1482

Fixes: https://github.com/pagespeed/ngx_pagespeed/issues/968