### PR TITLE
Update pagespeed_libraries_generator.sh for Ubuntu

### DIFF
--- a/scripts/pagespeed_libraries_generator.sh
+++ b/scripts/pagespeed_libraries_generator.sh
@@ -27,8 +27,9 @@
 # Author: vid@zippykid.com (Vid Luther)
 #         jefftk@google.com (Jeff Kaufman)
 
-URL="https://raw.githubusercontent.com/pagespeed/mod_pagespeed/master/net/instaweb/genfiles/conf/pagespeed_libraries.conf"
-curl -L -s -S "$URL" \
+URL="https://raw.githubusercontent.com/pagespeed/mod_pagespeed/master/"
+URL2="net/instaweb/genfiles/conf/pagespeed_libraries.conf"
+curl -L -s -S "$URL""$URL2" \
     | grep ModPagespeedLibrary \
     | while read library size hash url ; do
   echo "  pagespeed Library $size $hash $url;"

--- a/scripts/pagespeed_libraries_generator.sh
+++ b/scripts/pagespeed_libraries_generator.sh
@@ -27,8 +27,7 @@
 # Author: vid@zippykid.com (Vid Luther)
 #         jefftk@google.com (Jeff Kaufman)
 
-URL="https://github.com/pagespeed/mod_pagespeed/raw/master/"
-URL+="net/instaweb/genfiles/conf/pagespeed_libraries.conf"
+URL="https://raw.githubusercontent.com/pagespeed/mod_pagespeed/master/net/instaweb/genfiles/conf/pagespeed_libraries.conf"
 curl -L -s -S "$URL" \
     | grep ModPagespeedLibrary \
     | while read library size hash url ; do


### PR DESCRIPTION
pagespeed_libraries_generator.sh script gives error in Ubuntu

'pagespeed_libraries_generator.sh: 17: pagespeed_libraries_generator.sh: URL+=net/instaweb/genfiles/conf/pagespeed_libraries.conf: not found'

I don't understand why there are 2 lines for the URL when it can be simply switched into one.