### PR TITLE
nginx 1.13.4: Fix compilation error

### DIFF
--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -3019,13 +3019,17 @@ ngx_int_t ps_preaccess_handler(ngx_http_request_t* r) {
   ph = cmcf->phase_engine.handlers;
 
   i = r->phase_handler;
+
   // move handlers before try_files && content phase
+  // As of nginx 1.13.4 we will be right before the try_files module
+  #if (nginx_version < 1013004)
   while (ph[i + 1].checker != ngx_http_core_try_files_phase &&
          ph[i + 1].checker != ngx_http_core_content_phase) {
     ph[i] = ph[i + 1];
     ph[i].next--;
     i++;
   }
+  #endif
 
   // insert ps phase handler
   ph[i].checker = ps_phase_handler;
@@ -3081,8 +3085,16 @@ ngx_int_t ps_init(ngx_conf_t* cf) {
     ngx_http_core_main_conf_t* cmcf = static_cast<ngx_http_core_main_conf_t*>(
         ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module));
 
+    int phase = NGX_HTTP_PRECONTENT_PHASE;
+
+    // As of nginx 1.13.4, try_files has changed.
+#if (nginx_version < 1013004)
+    phase = NGX_HTTP_PREACCESS_PHASE;
+#endif
+
     ngx_http_handler_pt* h = static_cast<ngx_http_handler_pt*>(
-        ngx_array_push(&cmcf->phases[NGX_HTTP_PREACCESS_PHASE].handlers));
+        ngx_array_push(&cmcf->phases[phase].handlers));
+
     if (h == NULL) {
       return NGX_ERROR;
     }


### PR DESCRIPTION
* Compilation of ngx_pagespeed broke with the following commit in
nginx: https://github.com/nginx/nginx/commit/129b06dc5dfab7b4513a4f274b3778cd9b8a6a22
This change intends to unbreak it while maintaining backwards
compatibility.

* updates the nginx testing-dependency to 1.13.4

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/1451