### PR TITLE
set buildtype from env PSOL_BUILDTYPE.

### DIFF
--- a/config
+++ b/config
@@ -19,6 +19,7 @@
 
 mod_pagespeed_dir="${MOD_PAGESPEED_DIR:-unset}"
 position_aux="${POSITION_AUX:-unset}"
+psol_buildtype="${PSOL_BUILDTYPE:-unset}"
 
 if [ "$mod_pagespeed_dir" = "unset" ] ; then
   mod_pagespeed_dir="$ngx_addon_dir/psol/include"
@@ -76,7 +77,6 @@ else
   exit 1
 fi
 
-psol_buildtype="${PSOL_BUILDTYPE:-unset}"
 if [ "$psol_buildtype" = "unset" ] ; then
   if [ "$NGX_DEBUG" = "YES" ]; then
     buildtype=Debug

--- a/config
+++ b/config
@@ -15,6 +15,7 @@
 # Environment Variables (Optional):
 #   MOD_PAGESPEED_DIR: absolute path to the mod_pagespeed/src directory
 #   PSOL_BINARY: absolute path to pagespeed_automatic.a
+#   PSOL_BUILDTYPE: Release or Debug
 
 mod_pagespeed_dir="${MOD_PAGESPEED_DIR:-unset}"
 position_aux="${POSITION_AUX:-unset}"
@@ -75,12 +76,17 @@ else
   exit 1
 fi
 
-if [ "$NGX_DEBUG" = "YES" ]; then
-  buildtype=Debug
-  # If we're using a psol tarball that doesn't contain Debug/ (which is the case
-  # from 1.12 onward) then this will be overriden to buildtype=Release below.
+psol_buildtype="${PSOL_BUILDTYPE:-unset}"
+if [ "$psol_buildtype" = "unset" ] ; then
+  if [ "$NGX_DEBUG" = "YES" ]; then
+    buildtype=Debug
+    # If we're using a psol tarball that doesn't contain Debug/ (which is the case
+    # from 1.12 onward) then this will be overriden to buildtype=Release below.
+  else
+    buildtype=Release
+  fi
 else
-  buildtype=Release
+  buildtype=$psol_buildtype
 fi
 
 # If the compiler is gcc, we want to use g++ to link, if at all possible,
@@ -165,8 +171,6 @@ Use the available Release binaries?"
     psol_library_dir="$ngx_addon_dir/psol/lib/$buildtype/$os_name/$arch_name"
     psol_binary="$psol_library_dir/pagespeed_automatic.a"
   fi
-else
-  buildtype=Release
 fi
 
 echo "mod_pagespeed_dir=$mod_pagespeed_dir"

--- a/config
+++ b/config
@@ -165,6 +165,8 @@ Use the available Release binaries?"
     psol_library_dir="$ngx_addon_dir/psol/lib/$buildtype/$os_name/$arch_name"
     psol_binary="$psol_library_dir/pagespeed_automatic.a"
   fi
+else
+  buildtype=Release
 fi
 
 echo "mod_pagespeed_dir=$mod_pagespeed_dir"


### PR DESCRIPTION
Hi,

I gave the PSOL_BINARY environment variable to skip queries due to # 1332 change on build with `--with-debug`. Then, since `buildtype=Debug` is set, there is no file to include.

I want to use `buildtype=$PSOL_BUILDTYPE` if there is a PSOL_BUILDTYPE environment to avoid that case.
