### PR TITLE
F_SETPIPE_SZ: check for existence before using

### DIFF
--- a/src/ngx_event_connection.cc
+++ b/src/ngx_event_connection.cc
@@ -57,7 +57,9 @@ bool NgxEventConnection::Init(ngx_cycle_t* cycle) {
     // See https://github.com/pagespeed/ngx_pagespeed/issues/1380
     // TODO(oschaaf): Consider implementing a queueing mechanism for retrying
     // failed writes.
+#ifdef F_SETPIPE_SZ
     fcntl(pipe_write_fd_, F_SETPIPE_SZ, 200*1024 /* minimal amount of bytes */);
+#endif
     return true;
   }
   close(file_descriptors[0]);


### PR DESCRIPTION
Kernels before 2.6.35 do not have F_SETPIPE_SZ defined.

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/1503