### PR TITLE
Fix setting 'gzip_proxied' when applying gzip settings

### DIFF
--- a/src/ngx_gzip_setter.cc
+++ b/src/ngx_gzip_setter.cc
@@ -313,7 +313,7 @@ void NgxGZipSetter::EnableGZipForLocation(ngx_conf_t* cf) {
   }
   if (gzip_proxied_command_.command_) {
     SetNgxConfBitmask(
-        cf, &gzip_http_version_command_, NGX_HTTP_GZIP_PROXIED_ANY);
+        cf, &gzip_proxied_command_, NGX_HTTP_GZIP_PROXIED_ANY);
   }
 
   // This is actually the most prone to future API changes, because gzip_types


### PR DESCRIPTION
This fix should be fairly self-explanatory when viewing the code, but the code was setting the wrong command (and may have been screwing with `gzip_http_version`). This meant that `ngx_pagespeed`'s usage of gzip wouldn't work with CDNs as any fetch with a `Via` header would get the non-gzip version of a file.