### PR TITLE
Properly iterate modules looking for gzip commands

### DIFF
--- a/src/ngx_gzip_setter.cc
+++ b/src/ngx_gzip_setter.cc
@@ -108,10 +108,10 @@ void NgxGZipSetter::Init(ngx_conf_t* cf) {
 #if (NGX_HTTP_GZIP)
   bool gzip_signature_mismatch = false;
   bool other_signature_mismatch = false;
-  for (int m = 0; ngx_modules[m] != NULL; m++) {
-    if (ngx_modules[m]->commands != NULL) {
-      for (int c = 0; ngx_modules[m]->commands[c].name.len; c++) {
-        ngx_command_t* current_command =& ngx_modules[m]->commands[c];
+  for (int m = 0; cf->cycle->modules[m] != NULL; m++) {
+    if (cf->cycle->modules[m]->commands != NULL) {
+      for (int c = 0; cf->cycle->modules[m]->commands[c].name.len; c++) {
+        ngx_command_t* current_command =& cf->cycle->modules[m]->commands[c];
 
         // We look for the gzip command, and the exact signature we trust
         // this means configured as an config location offset
@@ -124,7 +124,7 @@ void NgxGZipSetter::Init(ngx_conf_t* cf) {
           if (IsNgxFlagCommand(current_command)) {
             current_command->set = ngx_gzip_redirect_conf_set_flag_slot;
             gzip_command_.command_ = current_command;
-            gzip_command_.module_ = ngx_modules[m];
+            gzip_command_.module_ = cf->cycle->modules[m];
             enabled_ = 1;
           } else {
             ngx_conf_log_error(
@@ -139,7 +139,7 @@ void NgxGZipSetter::Init(ngx_conf_t* cf) {
           if (IsNgxEnumCommand(current_command)) {
             current_command->set = ngx_gzip_redirect_conf_set_enum_slot;
             gzip_http_version_command_.command_ = current_command;
-            gzip_http_version_command_.module_ = ngx_modules[m];
+            gzip_http_version_command_.module_ = cf->cycle->modules[m];
           } else {
             ngx_conf_log_error(
                 NGX_LOG_WARN, cf, 0,
@@ -153,7 +153,7 @@ void NgxGZipSetter::Init(ngx_conf_t* cf) {
           if (IsNgxBitmaskCommand(current_command)) {
             current_command->set = ngx_gzip_redirect_conf_set_bitmask_slot;
             gzip_proxied_command_.command_ = current_command;
-            gzip_proxied_command_.module_ = ngx_modules[m];
+            gzip_proxied_command_.module_ = cf->cycle->modules[m];
           } else {
             ngx_conf_log_error(
                 NGX_LOG_WARN, cf, 0,
@@ -167,7 +167,7 @@ void NgxGZipSetter::Init(ngx_conf_t* cf) {
           if (IsNgxHttpTypesCommand(current_command)) {
             current_command->set = ngx_gzip_redirect_http_types_slot;
             gzip_http_types_command_.command_ = current_command;
-            gzip_http_types_command_.module_ = ngx_modules[m];
+            gzip_http_types_command_.module_ = cf->cycle->modules[m];
           } else {
             ngx_conf_log_error(
                 NGX_LOG_WARN, cf, 0,
@@ -181,7 +181,7 @@ void NgxGZipSetter::Init(ngx_conf_t* cf) {
           if (IsNgxFlagCommand(current_command)) {
             current_command->set = ngx_gzip_redirect_conf_set_flag_slot;
             gzip_vary_command_.command_ = current_command;
-            gzip_vary_command_.module_ = ngx_modules[m];
+            gzip_vary_command_.module_ = cf->cycle->modules[m];
           } else {
             ngx_conf_log_error(
                 NGX_LOG_WARN, cf, 0,


### PR DESCRIPTION
This change may or may not be needed. I spent a frustratingly long time trying to get gzip working with `ngx_pagespeed` in production, as I kept getting getting the `gzip command not found` error. I eventually got it working, and thought this change was the key, but I tried excluding it and my setup still worked, so now I'm not sure. During the journey of trying to get things working I changed to NGINX 1.14.0 as well as built `ngx_pagespeed` from a git checkout (so I could build up my own fork), so multiple things changed along the way. I unfortunately don't have the time to do a full test of changing a single variable at a time to find what really fixed my issues.

That said, NGINX does [list this change](https://www.nginx.com/blog/nginx-dynamic-modules-how-they-work/#ngxToCycle) as the "proper" way to iterate modules when writing a dynamic module. It's not mentioned, but presumably this doesn't interfere with building as a static module.

@oschaaf, perhaps you can take a look at the change and make a judgement call. I do believe there's a screw loose somewhere with gzip support (I was definitely getting `gzip command not found` with NGINX 1.12.2 and `ngx_pagespeed` v1.13.35.2-stable despite the gzip module being included, confirmed multiple times over), and this may be it. In theory even if this isn't it, this change should be "harmless".